### PR TITLE
Add reset and prev to macro context

### DIFF
--- a/doc/1.0/reference.adoc
+++ b/doc/1.0/reference.adoc
@@ -60,10 +60,19 @@ TransformerContext = {
     done: boolean,
     value: Syntax
   }
+  prev: () -> {
+    done: boolean,
+    value: Syntax
+  }
+  reset: () -> undefined
 }
 ----
 
 Each call to `next` returns the <<synobj, syntax object>> following the transformer call. If `next` is called with a string, the specified grammar production is matched.
+
+A call to `prev` returns the <<synobj, syntax object>> preceding that returned by the last call to `next`. If the previous term resulted from a transformation, the object returned from a call to `prev` will be the that of the original, unaltered syntax. Calls to `prev` will not continue before the transformer call.
+
+The `reset()` method returns the context to its original state (before any calls to `next`).
 
 The `name()` method returns the syntax object of the macro name at the macro invocation site. This is usefulfootnote:[or will become useful as more features are implemented in Sweet] because it allows a macro transformer to get access to the lexical context at the invocation site.
 

--- a/doc/1.0/reference.html
+++ b/doc/1.0/reference.html
@@ -143,11 +143,22 @@
     done: boolean,
     value: Syntax
   }
+  prev: () -&gt; {
+    done: boolean,
+    value: Syntax
+  }
+  reset: () -&gt; undefined
 }</pre>
 </div>
 </div>
 <div class="paragraph">
 <p>Each call to <code>next</code> returns the <a href="#synobj">syntax object</a> following the transformer call. If <code>next</code> is called with a string, the specified grammar production is matched.</p>
+</div>
+<div class="paragraph">
+<p>A call to <code>prev</code> returns the <a href="#synobj">syntax object</a> preceding that returned by the last call to <code>next</code>. If the previous term resulted from a transformation, the object returned from a call to <code>prev</code> will be the that of the original, unaltered syntax. Calls to <code>prev</code> will not continue before the transformer call.</p>
+</div>
+<div class="paragraph">
+<p>The <code>reset()</code> method returns the context to its original state (before any calls to <code>next</code>).</p>
 </div>
 <div class="paragraph">
 <p>The <code>name()</code> method returns the syntax object of the macro name at the macro invocation site. This is useful<span class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnote_1" title="View footnote.">1</a>]</span> because it allows a macro transformer to get access to the lexical context at the invocation site.</p>

--- a/src/enforester.js
+++ b/src/enforester.js
@@ -332,7 +332,7 @@ export class Enforester {
     let lookahead = this.peek();
 
     if (this.term === null && this.isCompiletimeTransform(lookahead)) {
-      this.rest = this.expandMacro().concat(this.rest);
+      this.rest = this.expandMacro();
       lookahead = this.peek();
       this.term = null;
     }
@@ -1048,8 +1048,7 @@ export class Enforester {
     }
 
     if (this.term === null && this.isCompiletimeTransform(lookahead)) {
-      let result = this.expandMacro();
-      this.rest = result.concat(this.rest);
+      this.rest = this.expandMacro();
       return EXPR_LOOP_EXPANSION;
     }
 
@@ -1852,7 +1851,7 @@ export class Enforester {
       return stx.addScope(introducedScope, this.context.bindings, ALL_PHASES, { flip: true });
     });
 
-    return result;
+    return result.concat(ctx[Symbol.for('enforester')].rest);
 
   }
 

--- a/src/macro-context.js
+++ b/src/macro-context.js
@@ -10,6 +10,7 @@ const Nothing = Maybe.Nothing;
 
 const symWrap = Symbol('wrapper');
 const symName = Symbol('name');
+const symEnf = Symbol('enforester');
 const symResetValues = Symbol('resetValues');
 
 const getLineNumber = t => {
@@ -140,9 +141,7 @@ ctx :: {
 */
 export default class MacroContext {
   constructor(enf, name, context, useScope, introducedScope) {
-    // todo: perhaps replace with a symbol to keep mostly private?
-    this._enf = enf;
-    const { term, rest, prev, done} = enf;
+    const { term, rest, prev, done} = this[symEnf] = enf;
     this[symResetValues] = { term, rest, prev, done };
     this[symName] = name;
     this.context = context;
@@ -161,11 +160,11 @@ export default class MacroContext {
   }
 
   reset() {
-    Object.assign(this._enf, this[symResetValues]);
+    Object.assign(this[symEnf], this[symResetValues]);
   }
 
   next(type = 'Syntax') {
-    if (this._enf.rest.size === 0) {
+    if (this[symEnf].rest.size === 0) {
       return {
         done: true,
         value: null,
@@ -175,13 +174,13 @@ export default class MacroContext {
     switch(type) {
       case 'AssignmentExpression':
       case 'expr':
-        value = this._enf.enforestExpressionLoop();
+        value = this[symEnf].enforestExpressionLoop();
         break;
       case 'Expression':
-        value = this._enf.enforestExpression();
+        value = this[symEnf].enforestExpression();
         break;
       case 'Syntax':
-        value = this._enf.advance();
+        value = this[symEnf].advance();
         if (!this.noScopes) {
           value = value
             .addScope(this.useScope, this.context.bindings, ALL_PHASES)

--- a/src/macro-context.js
+++ b/src/macro-context.js
@@ -10,6 +10,7 @@ const Nothing = Maybe.Nothing;
 
 const symWrap = Symbol('wrapper');
 const symName = Symbol('name');
+const symResetValues = Symbol('resetValues');
 
 const getLineNumber = t => {
   if (t instanceof Syntax) {
@@ -141,6 +142,8 @@ export default class MacroContext {
   constructor(enf, name, context, useScope, introducedScope) {
     // todo: perhaps replace with a symbol to keep mostly private?
     this._enf = enf;
+    const { term, rest, prev, done} = enf;
+    this[symResetValues] = { term, rest, prev, done };
     this[symName] = name;
     this.context = context;
     if (useScope && introducedScope) {
@@ -155,6 +158,10 @@ export default class MacroContext {
 
   name() {
     return new SyntaxOrTermWrapper(this[symName], this.context);
+  }
+
+  reset() {
+    Object.assign(this._enf, this[symResetValues]);
   }
 
   next(type = 'Syntax') {

--- a/test/test_macro_context.js
+++ b/test/test_macro_context.js
@@ -104,6 +104,31 @@ test('a macro context should have a name', t => {
   t.true(ctx.name().val() === 'foo');
 });
 
+test('a macro context should provide the next term', t => {
+  let enf = makeEnforester('a');
+  let ctx = new MacroContext(enf, 'foo', enf.context);
+  t.true(ctx.next().value.val() === 'a');
+});
+
+test('a macro context should provide the previous term', t => {
+  let enf = makeEnforester('a b');
+  let ctx = new MacroContext(enf, 'foo');
+  ctx.next(); ctx.next();
+  t.true(ctx.prev().value.val() === 'a');
+});
+
+test('a macro context should not allow recession beyond the transform\'s call site', t => {
+  let enf = makeEnforester('a b');
+  let ctx = new MacroContext(enf, 'foo', enf.context);
+  ctx.next(); ctx.next();
+  t.true(ctx.prev().value.val() === 'a');
+
+  let { value, done } = ctx.prev();
+  t.true(value === null && done);
+  ({ value, done } = ctx.prev());
+   t.true(value === null && done);
+});
+
 test('a macro context should be resettable', t => {
   let enf = makeEnforester('a b c');
   let ctx = new MacroContext(enf, 'foo', enf.context);

--- a/test/test_macro_context.js
+++ b/test/test_macro_context.js
@@ -103,3 +103,22 @@ test('a macro context should have a name', t => {
   let ctx = new MacroContext(enf, Syntax.fromIdentifier('foo'), {});
   t.true(ctx.name().val() === 'foo');
 });
+
+test('a macro context should be resettable', t => {
+  let enf = makeEnforester('a b c');
+  let ctx = new MacroContext(enf, 'foo', enf.context);
+  const val = v => v.val();
+
+  let [a1, b1, c1] = [...ctx].map(val);
+  t.true(ctx.next().done);
+
+  ctx.reset();
+
+  let nxt = ctx.next();
+  t.false(nxt.done);
+
+  let [a2, b2, c2] = [nxt.value, ...ctx].map(val);
+  t.true(a1 === a2);
+  t.true(b1 === b2);
+  t.true(c1 === c2);
+});

--- a/test/test_macro_expansion.js
+++ b/test/test_macro_expansion.js
@@ -172,12 +172,20 @@ test('should handle the full macro context api', () => {
     syntaxrec def = function(ctx) {
       let id = ctx.next().value;
       let parens = ctx.next().value;
+      ctx.reset();
+      ctx.next(); ctx.next();
       let body = ctx.next().value;
+
 
       let parenCtx = parens.inner();
       let paren_id = parenCtx.next().value;
       parenCtx.next() // =
-      let paren_init = parenCtx.next('expr').value;
+      parenCtx.next('expr'); // 1 + 10 + 100
+      parenCtx.prev(); // +
+      parenCtx.prev(); // 10
+      parenCtx.prev(); // +
+      parenCtx.prev(); // 1
+      let paren_init = parenCtx.next('expr').value; // + 10 + 100
 
       let bodyCtx = body.inner();
       let b = [];
@@ -191,7 +199,7 @@ test('should handle the full macro context api', () => {
       }\`;
     }
 
-    def foo (x = 10 + 100) { return x; }
+    def foo (x = 1 + 10 + 100) { return x; }
     output = foo();
     `, 110);
 });


### PR DESCRIPTION
This PR addresses #537.

The `reset` method simply reverts the macro context's enforester to the state it was in when the context was instantiated. This allows for many of the requests in #529.

I considered a few of the alternate naming suggestions, but none of them was a compelling alternative (though PHP does use `rewind`).