### PR TITLE
Add reset and expand to MacroContext

### DIFF
--- a/doc/1.0/reference.adoc
+++ b/doc/1.0/reference.adoc
@@ -56,16 +56,35 @@ A transformer context is an iterable object that provides access to syntax at th
 ----
 TransformerContext = {
   name: () -> Syntax
-  next: (string?) -> {
+  next: () -> {
     done: boolean,
     value: Syntax
   }
+  expand: (string) -> {
+    done: boolean,
+    value: Syntax
+  }
+  reset: () -> undefined
 }
 ----
 
-Each call to `next` returns the <<synobj, syntax object>> following the transformer call. If `next` is called with a string, the specified grammar production is matched.
+Each call to `next` returns the <<synobj, syntax object>> following the transformer call.
+
+A call to `expand` matches the specified grammar production.
 
 The `name()` method returns the syntax object of the macro name at the macro invocation site. This is usefulfootnote:[or will become useful as more features are implemented in Sweet] because it allows a macro transformer to get access to the lexical context at the invocation site.
+
+Calling `reset` returns the context to its initial state.
+
+[source, javascript]
+----
+syntax m = function (ctx) {
+  ctx.expand('expr');
+  ctx.reset();
+  return #`${ctx.next().value} + 24`; // 42 + 24
+}
+m 42 + 66
+----
 
 anchor:synobj[]
 

--- a/doc/1.0/reference.html
+++ b/doc/1.0/reference.html
@@ -139,18 +139,39 @@
 <div class="content">
 <pre>TransformerContext = {
   name: () -&gt; Syntax
-  next: (string?) -&gt; {
+  next: () -&gt; {
     done: boolean,
     value: Syntax
   }
+  expand: (string) -&gt; {
+    done: boolean,
+    value: Syntax
+  }
+  reset: () -&gt; undefined
 }</pre>
 </div>
 </div>
 <div class="paragraph">
-<p>Each call to <code>next</code> returns the <a href="#synobj">syntax object</a> following the transformer call. If <code>next</code> is called with a string, the specified grammar production is matched.</p>
+<p>Each call to <code>next</code> returns the <a href="#synobj">syntax object</a> following the transformer call.</p>
+</div>
+<div class="paragraph">
+<p>A call to <code>expand</code> matches the specified grammar production.</p>
 </div>
 <div class="paragraph">
 <p>The <code>name()</code> method returns the syntax object of the macro name at the macro invocation site. This is useful<span class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnote_1" title="View footnote.">1</a>]</span> because it allows a macro transformer to get access to the lexical context at the invocation site.</p>
+</div>
+<div class="paragraph">
+<p>Calling <code>reset</code> returns the context to its initial state.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-javascript" data-lang="javascript">syntax m = function (ctx) {
+  ctx.expand('expr');
+  ctx.reset();
+  return #`${ctx.next().value} + 24`; // 42 + 24
+}
+m 42 + 66</code></pre>
+</div>
 </div>
 <div class="paragraph">
 <p><a id="synobj"></a></p>

--- a/src/enforester.js
+++ b/src/enforester.js
@@ -332,7 +332,7 @@ export class Enforester {
     let lookahead = this.peek();
 
     if (this.term === null && this.isCompiletimeTransform(lookahead)) {
-      this.rest = this.expandMacro().concat(this.rest);
+      this.rest = this.expandMacro();
       lookahead = this.peek();
       this.term = null;
     }
@@ -1048,8 +1048,7 @@ export class Enforester {
     }
 
     if (this.term === null && this.isCompiletimeTransform(lookahead)) {
-      let result = this.expandMacro();
-      this.rest = result.concat(this.rest);
+      this.rest = this.expandMacro();
       return EXPR_LOOP_EXPANSION;
     }
 
@@ -1852,7 +1851,7 @@ export class Enforester {
       return stx.addScope(introducedScope, this.context.bindings, ALL_PHASES, { flip: true });
     });
 
-    return result;
+    return result.concat(ctx._rest(this));
 
   }
 

--- a/src/macro-context.js
+++ b/src/macro-context.js
@@ -163,7 +163,10 @@ export default class MacroContext {
   expand(type) {
     const enf = privateData.get(this).enf;
     if (enf.rest.size === 0) {
-      return null;
+      return {
+        done: true,
+        value: null
+      };
     }
     let value;
     switch(type) {
@@ -177,7 +180,10 @@ export default class MacroContext {
       default:
         throw new Error('Unknown term type: ' + type);
     }
-    return new SyntaxOrTermWrapper(value, this.context);
+    return {
+      done: false,
+      value: new SyntaxOrTermWrapper(value, this.context)
+    };
   }
 
   _rest(enf) {

--- a/src/macro-context.js
+++ b/src/macro-context.js
@@ -157,11 +157,11 @@ export default class MacroContext {
     return new SyntaxOrTermWrapper(this[symName], this.context);
   }
 
-  next(type = 'Syntax') {
+  expand(type) {
     if (this._enf.rest.size === 0) {
       return {
         done: true,
-        value: null,
+        value: null
       };
     }
     let value;
@@ -173,20 +173,28 @@ export default class MacroContext {
       case 'Expression':
         value = this._enf.enforestExpression();
         break;
-      case 'Syntax':
-        value = this._enf.advance();
-        if (!this.noScopes) {
-          value = value
-            .addScope(this.useScope, this.context.bindings, ALL_PHASES)
-            .addScope(this.introducedScope, this.context.bindings, ALL_PHASES, { flip: true });
-        }
-        break;
       default:
         throw new Error('Unknown term type: ' + type);
     }
+    return new SyntaxOrTermWrapper(value, this.context);
+  }
+
+  next() {
+    if (this._enf.rest.size === 0) {
+      return {
+        done: true,
+        value: null
+      };
+    }
+    let value = this._enf.advance();
+    if (!this.noScopes) {
+      value = value
+        .addScope(this.useScope, this.context.bindings, ALL_PHASES)
+        .addScope(this.introducedScope, this.context.bindings, ALL_PHASES, { flip: true });
+    }
     return {
       done: false,
-      value: new SyntaxOrTermWrapper(value, this.context),
+      value: new SyntaxOrTermWrapper(value, this.context)
     };
   }
 }

--- a/test/test_macro_context.js
+++ b/test/test_macro_context.js
@@ -104,10 +104,23 @@ test('a macro context should have a name', t => {
   t.true(ctx.name().val() === 'foo');
 });
 
-test('a macro context should have a reset method.', t => {
-  let enf = makeEnforester('a');
-  let ctx = new MacroContext(enf, Syntax.fromIdentifier('foo'), {});
-  t.true(ctx != null);
+test('a macro context should be resettable', t => {
+  let enf = makeEnforester('a b c');
+  let ctx = new MacroContext(enf, 'foo', enf.context);
+  const val = v => v.val();
+
+  let [a1, b1, c1] = [...ctx].map(val);
+  t.true(ctx.next().done);
+
+  ctx.reset();
+
+  let nxt = ctx.next();
+  t.false(nxt.done);
+
+  let [a2, b2, c2] = [nxt.value, ...ctx].map(val);
+  t.true(a1 === a2);
+  t.true(b1 === b2);
+  t.true(c1 === c2);
 });
 
 test('an enforester should be able to access a macro context\'s syntax list', t => {

--- a/test/test_macro_context.js
+++ b/test/test_macro_context.js
@@ -103,3 +103,15 @@ test('a macro context should have a name', t => {
   let ctx = new MacroContext(enf, Syntax.fromIdentifier('foo'), {});
   t.true(ctx.name().val() === 'foo');
 });
+
+test('a macro context should have a reset method.', t => {
+  let enf = makeEnforester('a');
+  let ctx = new MacroContext(enf, Syntax.fromIdentifier('foo'), {});
+  t.true(ctx != null);
+});
+
+test('an enforester should be able to access a macro context\'s syntax list', t => {
+  let enf = makeEnforester('a');
+  let ctx = new MacroContext(enf, Syntax.fromIdentifier('foo'), {});
+  t.true(ctx._rest(enf) instanceof List);
+});

--- a/test/test_macro_expansion.js
+++ b/test/test_macro_expansion.js
@@ -131,7 +131,7 @@ test('should handle expansion that takes an argument', () => {
 test('should handle expansion that matches an expression argument', () => {
   testParse(`
     syntaxrec m = function(ctx) {
-      let x = ctx.expand('expr');
+      let x = ctx.expand('expr').value;
       return #\`40 + \${x}\`;
     }
     m 2;
@@ -179,7 +179,7 @@ test('should handle the full macro context api', () => {
       let parenCtx = parens.inner();
       let paren_id = parenCtx.next().value;
       parenCtx.next() // =
-      let paren_init = parenCtx.expand('expr');
+      let paren_init = parenCtx.expand('expr').value;
 
       let bodyCtx = body.inner();
       let b = [];
@@ -203,7 +203,7 @@ test('should handle iterators inside a syntax template', t => {
     syntax let = function (ctx) {
       let ident = ctx.next().value;
       ctx.next();
-      let init = ctx.expand('expr');
+      let init = ctx.expand('expr').value;
       return #\`
         (function (\${ident}) {
           \${ctx}

--- a/test/test_macro_expansion.js
+++ b/test/test_macro_expansion.js
@@ -85,7 +85,7 @@ m 42`, stmt, {
 test("should handle expansion that eats an expression", function () {
   testParse(`
 syntaxrec m = function(ctx) {
-  let term = ctx.next('expr')
+  let term = ctx.expand('expr')
   return #\`200\`
 }
 m 100 + 200`, stmt, {
@@ -131,7 +131,7 @@ test('should handle expansion that takes an argument', () => {
 test('should handle expansion that matches an expression argument', () => {
   testParse(`
     syntaxrec m = function(ctx) {
-      let x = ctx.next('expr').value;
+      let x = ctx.expand('expr');
       return #\`40 + \${x}\`;
     }
     m 2;
@@ -177,7 +177,7 @@ test('should handle the full macro context api', () => {
       let parenCtx = parens.inner();
       let paren_id = parenCtx.next().value;
       parenCtx.next() // =
-      let paren_init = parenCtx.next('expr').value;
+      let paren_init = parenCtx.expand('expr');
 
       let bodyCtx = body.inner();
       let b = [];
@@ -201,7 +201,7 @@ test('should handle iterators inside a syntax template', t => {
     syntax let = function (ctx) {
       let ident = ctx.next().value;
       ctx.next();
-      let init = ctx.next('expr').value;
+      let init = ctx.expand('expr');
       return #\`
         (function (\${ident}) {
           \${ctx}

--- a/test/test_macro_expansion.js
+++ b/test/test_macro_expansion.js
@@ -171,6 +171,8 @@ test('should handle the full macro context api', () => {
   testEval(`
     syntaxrec def = function(ctx) {
       let id = ctx.next().value;
+      ctx.reset();
+      id = ctx.next().value;
       let parens = ctx.next().value;
       let body = ctx.next().value;
 

--- a/test/test_macro_expansion.js
+++ b/test/test_macro_expansion.js
@@ -237,3 +237,19 @@ test('should allow macros to be defined with punctuators', t => {
     output = *
   `, 42);
 });
+
+test('should allow the macro context to be reset', t => {
+  testEval(`
+    syntax m = ctx => {
+      ctx.expand('expr'); // 42 + 66
+      // oops, just wanted one token
+      ctx.reset();
+      let value = ctx.next().value; // 42
+      ctx.next();
+      ctx.next();
+      return #\`\${value}\`;
+    }
+
+    output = m 42 + 66
+  `, 42);
+});


### PR DESCRIPTION
Re-submit of #552.

This PR adds `.reset` which allows the context to be returned to its initial state. It also removes the enforestation logic from `.next` to `.expand`.