### PR TITLE
Add ability to match more terms in MacroContext::expand

### DIFF
--- a/doc/1.0/reference.adoc
+++ b/doc/1.0/reference.adoc
@@ -70,7 +70,52 @@ TransformerContext = {
 
 Each call to `next` returns the <<synobj, syntax object>> following the transformer call.
 
-A call to `expand` matches the specified grammar production.
+A call to `expand` initiates expansion at the current state of the iterator and matches the specified grammar production. Matching is "greedy" so `expand('expr')` with the syntax `1 + 2` matches the entire binary expression rather than just `1`. The following productions are accepted by `expand`:
+
+- `Statement` with alias `stmt`
+- `AssignmentExpression` with alias `expr`
+- `Expression`
+- `BlockStatement`
+- `WhileStatement`
+- `IfStatement`
+- `ForStatement`
+- `SwitchStatement`
+- `BreakStatement`
+- `ContinueStatement`
+- `DebuggerStatement`
+- `WithStatement`
+- `TryStatement`
+- `ThrowStatement`
+- `ClassDeclaration`
+- `FunctionDeclaration`
+- `LabeledStatement`
+- `VariableDeclarationStatement`
+- `ReturnStatement`
+- `ExpressionStatement`
+- `YieldExpression`
+- `ClassExpression`
+- `ArrowExpression`
+- `NewExpression`
+- `ThisExpression`
+- `FunctionExpression`
+- `IdentifierExpression`
+- `LiteralNumericExpression`
+- `LiteralInfinityExpression`
+- `LiteralStringExpression`
+- `TemplateExpression`
+- `LiteralBooleanExpression`
+- `LiteralNullExpression`
+- `LiteralRegExpExpression`
+- `ObjectExpression`
+- `ArrayExpression`
+- `UnaryExpression`
+- `UpdateExpression`
+- `BinaryExpression`
+- `StaticMemberExpression`
+- `ComputedMemberExpression`
+- `AssignmentExpression`
+- `CompoundAssignmentExpression`
+- `ConditionalExpression`
 
 The `name()` method returns the syntax object of the macro name at the macro invocation site. This is usefulfootnote:[or will become useful as more features are implemented in Sweet] because it allows a macro transformer to get access to the lexical context at the invocation site.
 

--- a/doc/1.0/tutorial.adoc
+++ b/doc/1.0/tutorial.adoc
@@ -131,7 +131,7 @@ An iterator over the syntax where the macro was called. It has the type:
 +
 ----
 {
-  next: (string?) -> {
+  next: () -> {
     done: boolean,
     value: Syntax
   }
@@ -156,7 +156,7 @@ We only need one new feature you haven't seen yet:
 syntax let = function (ctx) {
   let ident = ctx.next().value;
   ctx.next(); // eat `=`
-  let init = ctx.next('expr').value; // <1>
+  let init = ctx.expand('expr').value; // <1>
   return #`
     (function (${ident}) {
       ${ctx} // <2>
@@ -167,7 +167,7 @@ syntax let = function (ctx) {
 let bb8 = new Droid('BB-8', 'orange');
 console.log(bb8.beep());
 ----
-<1> Match an expression
+<1> Expand the syntax until an expression is matched
 <2> A macro context in the template will consume the iterator
 
 .(Expansion)
@@ -178,7 +178,7 @@ console.log(bb8.beep());
 })(Droid.create("BB-8", "orange"));
 ----
 
-Calling `next` with a string argument allows us to specify the grammar production we want to match; in this case we are matching an expression. You can think matching against a grammar production a little like matching an implicitly-delimited syntax object; these matches group multiple syntax object together.
+Calling `expand` allows us to specify the grammar production we want to match; in this case we are matching an expression. You can think matching against a grammar production a little like matching an implicitly-delimited syntax object; these matches group multiple syntax object together.
 
 
 == Sweet Cond
@@ -194,15 +194,15 @@ syntax cond = function (ctx) {
   let result = #``;
   for (let stx of bodyCtx) { // <2>
     if (stx.isKeyword('case')) { // <3>
-      let test = bodyCtx.next('expr').value;
+      let test = bodyCtx.expand('expr').value;
       // eat `:`
       bodyCtx.next();
-      let r = bodyCtx.next('expr').value;
+      let r = bodyCtx.expand('expr').value;
       result = result.concat(#`${test} ? ${r} :`);
     } else if (stx.isKeyword('default')) {
       // eat `:`
       bodyCtx.next();
-      let r = bodyCtx.next('expr').value;
+      let r = bodyCtx.expand('expr').value;
       result = result.concat(#`${r}`);
     } else {
       throw new Error('unknown syntax: ' + stx);

--- a/src/errors.js
+++ b/src/errors.js
@@ -3,10 +3,11 @@ export function expect(cond, message, offendingSyntax, rest) {
     let ctx = "";
     if (rest) {
       let ctx = rest.slice(0, 20).map(s => {
+        let val = s.isDelimiter() ? "( ... )" : s.val();
         if (s === offendingSyntax) {
-          return "__" + s.val() + "__";
+          return "__" + val + "__";
         }
-        return s.val();
+        return val;
       }).join(" ");
     }
     throw new Error("[error]: " + message + "\n" + ctx);

--- a/src/macro-context.js
+++ b/src/macro-context.js
@@ -173,6 +173,7 @@ export default class MacroContext {
         value: null
       };
     }
+    enf.expandMacro();
     let originalRest = enf.rest;
     let value;
     switch(type) {
@@ -220,38 +221,18 @@ export default class MacroContext {
         value = enf.enforestNewExpression();
         break;
       case 'ThisExpression':
-        value = enf.enforestThisExpression();
-        break;
       case 'FunctionExpression':
-        value = enf.enforestFunctionExpression();
-        break;
       case 'IdentifierExpression':
-        value = enf.enforestIdentifierExpression();
-        break;
       case 'LiteralNumericExpression':
       case 'LiteralInfinityExpression':
-        value = enf.enforestNumericLiteral();
-        break;
       case 'LiteralStringExpression':
-        value = enf.enforestStringLiteral();
-        break;
       case 'TemplateExpression':
-        value = enf.enforestTemplateLiteral();
-        break;
       case 'LiteralBooleanExpression':
-        value = enf.enforestBooleanLiteral();
-        break;
       case 'LiteralNullExpression':
-        value = enf.enforestNullLiteral();
-        break;
       case 'LiteralRegExpExpression':
-        value = enf.enforestRegularExpressionLiteral();
-        break;
       case 'ObjectExpression':
-        value = enf.enforestObjectExpression();
-        break;
       case 'ArrayExpression':
-        value = enf.enforestArrayExpression();
+        value = enf.enforestPrimaryExpression();
         break;
       case 'UnaryExpression':
       case 'UpdateExpression':

--- a/src/macro-context.js
+++ b/src/macro-context.js
@@ -1,5 +1,6 @@
 import MapSyntaxReducer from "./map-syntax-reducer";
 import reducer from "shift-reducer";
+import { expect } from './errors';
 import { List } from 'immutable';
 import { Enforester } from './enforester';
 import Syntax, { ALL_PHASES } from './syntax';
@@ -7,6 +8,7 @@ import * as _ from 'ramda';
 import { Maybe } from 'ramda-fantasy';
 const Just = Maybe.Just;
 const Nothing = Maybe.Nothing;
+
 
 const symWrap = Symbol('wrapper');
 const privateData = new WeakMap();
@@ -40,7 +42,7 @@ export class SyntaxOrTermWrapper {
       return stx.match(type, value);
     }
   }
-  
+
   isIdentifier(value) {
     return this.match("identifier", value);
   }
@@ -171,6 +173,7 @@ export default class MacroContext {
         value: null
       };
     }
+    let originalRest = enf.rest;
     let value;
     switch(type) {
       case 'AssignmentExpression':
@@ -179,6 +182,87 @@ export default class MacroContext {
         break;
       case 'Expression':
         value = enf.enforestExpression();
+        break;
+      case 'Statement':
+      case 'stmt':
+        value = enf.enforestStatement();
+        break;
+      case 'BlockStatement':
+      case 'WhileStatement':
+      case 'IfStatement':
+      case 'ForStatement':
+      case 'SwitchStatement':
+      case 'BreakStatement':
+      case 'ContinueStatement':
+      case 'DebuggerStatement':
+      case 'WithStatement':
+      case 'TryStatement':
+      case 'ThrowStatement':
+      case 'ClassDeclaration':
+      case 'FunctionDeclaration':
+      case 'LabeledStatement':
+      case 'VariableDeclarationStatement':
+      case 'ReturnStatement':
+      case 'ExpressionStatement':
+        value = enf.enforestStatement();
+        expect(_.whereEq({type}, value), `Expecting a ${type}`, value, originalRest);
+        break;
+      case 'YieldExpression':
+        value = enf.enforestYieldExpression();
+        break;
+      case 'ClassExpression':
+        value = enf.enforestClass({isExpr: true});
+        break;
+      case 'ArrowExpression':
+        value = enf.enforestArrowExpression();
+        break;
+      case 'NewExpression':
+        value = enf.enforestNewExpression();
+        break;
+      case 'ThisExpression':
+        value = enf.enforestThisExpression();
+        break;
+      case 'FunctionExpression':
+        value = enf.enforestFunctionExpression();
+        break;
+      case 'IdentifierExpression':
+        value = enf.enforestIdentifierExpression();
+        break;
+      case 'LiteralNumericExpression':
+      case 'LiteralInfinityExpression':
+        value = enf.enforestNumericLiteral();
+        break;
+      case 'LiteralStringExpression':
+        value = enf.enforestStringLiteral();
+        break;
+      case 'TemplateExpression':
+        value = enf.enforestTemplateLiteral();
+        break;
+      case 'LiteralBooleanExpression':
+        value = enf.enforestBooleanLiteral();
+        break;
+      case 'LiteralNullExpression':
+        value = enf.enforestNullLiteral();
+        break;
+      case 'LiteralRegExpExpression':
+        value = enf.enforestRegularExpressionLiteral();
+        break;
+      case 'ObjectExpression':
+        value = enf.enforestObjectExpression();
+        break;
+      case 'ArrayExpression':
+        value = enf.enforestArrayExpression();
+        break;
+      case 'UnaryExpression':
+      case 'UpdateExpression':
+      case 'BinaryExpression':
+      case 'StaticMemberExpression':
+      case 'ComputedMemberExpression':
+      case 'AssignmentExpression':
+      case 'CompoundAssignmentExpression':
+      case 'ConditionalExpression':
+        value = enf.enforestExpressionLoop();
+        expect(_.whereEq({type}, value), `Expecting a ${type}`, value, originalRest);
         break;
       default:
         throw new Error('Unknown term type: ' + type);

--- a/test/test_macro_expansion.js
+++ b/test/test_macro_expansion.js
@@ -253,3 +253,45 @@ test('should allow the macro context to be reset', t => {
     output = m 42 + 66
   `, 42);
 });
+
+test('should allow the macro context to match on a identifier expression', t => {
+  testEval(`
+    syntax m = ctx => {
+      let expr = ctx.expand('IdentifierExpression').value;
+      return #\`\${expr}\`;
+    }
+    var foo = 1;
+    output = m foo
+  `, 1);
+
+  testEval(`
+    syntax m = ctx => {
+      let expr = ctx.expand('IdentifierExpression').value;
+      return #\`1\`;
+    }
+    var foo = 1;
+    output = m foo + 1
+  `, 2);
+});
+
+test('should allow the macro context to match on a binary expression', t => {
+  testEval(`
+    syntax m = ctx => {
+      let expr = ctx.expand('BinaryExpression').value;
+      return #\`\${expr}\`;
+    }
+    output = m 1 + 1 - 1
+  `, 1);
+});
+
+test('should throw an error if the match fails for MacroContext::expand', t => {
+  t.throws(() => {
+    testEval(`
+      syntax m = ctx => {
+        let expr = ctx.expand('BinaryExpression').value;
+        return #\`\${expr}\`;
+      }
+      output = m foo
+    `, 1);
+  });
+});


### PR DESCRIPTION
You can now match against more grammar productions with the `MacroContext::expand` method:

```js
syntax m = ctx => {
  let expr = ctx.expand('BinaryExpression');
  // ...
}

syntax n = ctx => {
  let ident = ctx.expand('IdentifierExpression');
  // ...
}

m foo() + 100 - [1, 2, 3]   // <- everything is matched
n foo() + 100 - [1, 2, 3]   // <- only `foo` is matched
```