### PR TITLE
Fix Ex 5 in the tutorial to match its expansion

### DIFF
--- a/doc/1.0/tutorial.adoc
+++ b/doc/1.0/tutorial.adoc
@@ -157,6 +157,7 @@ syntax let = function (ctx) {
   let ident = ctx.next().value;
   ctx.next(); // eat `=`
   let init = ctx.expand('expr').value; // <1>
+  ctx.next(); // eat `;`
   return #`
     (function (${ident}) {
       ${ctx} // <2>

--- a/doc/1.0/tutorial.html
+++ b/doc/1.0/tutorial.html
@@ -277,6 +277,7 @@ We only need one new feature you haven&#8217;t seen yet:</p>
   let ident = ctx.next().value;
   ctx.next(); // eat `=`
   let init = ctx.expand('expr').value; <i class="conum" data-value="1"></i><b>(1)</b>
+  ctx.next(); // eat `;`
   return #`
     (function (${ident}) {
       ${ctx} <i class="conum" data-value="2"></i><b>(2)</b>


### PR DESCRIPTION
The expansion of the example 5 in the tutorial, with sweet.js version 2.0.0, gives for me:

    (function (bb8_5) {
      ;
      console.log(bb8_5.beep());
    }(new Droid("BB-8", "orange")));

So I added one more ctx.next() and rebuild the docs. Maybe would be better also a check to see if the `;` exists?