### PR TITLE
Add the ability to create a reset point on a macro context

### DIFF
--- a/doc/1.0/reference.adoc
+++ b/doc/1.0/reference.adoc
@@ -64,7 +64,8 @@ TransformerContext = {
     done: boolean,
     value: Syntax
   }
-  reset: () -> undefined
+  mark: () -> Marker
+  reset: (Marker?) -> undefined
 }
 ----
 
@@ -119,16 +120,27 @@ A call to `expand` initiates expansion at the current state of the iterator and 
 
 The `name()` method returns the syntax object of the macro name at the macro invocation site. This is usefulfootnote:[or will become useful as more features are implemented in Sweet] because it allows a macro transformer to get access to the lexical context at the invocation site.
 
-Calling `reset` returns the context to its initial state.
+A call to `mark` returns a pointer to the current state of the iterator.
+
+Calling `reset` with no arguments returns the context to its initial state, while passing a Marker instance returns the context to the state pointed to by the marker.
 
 [source, javascript]
 ----
 syntax m = function (ctx) {
   ctx.expand('expr');
   ctx.reset();
-  return #`${ctx.next().value} + 24`; // 42 + 24
+
+  const a = ctx.next().value;
+  ctx.next();
+
+  const marker = ctx.mark();
+  ctx.expand('expr');
+  ctx.reset(marker);
+
+  const b = ctx.next().value;
+  return #`${a} + ${b} + 24`; // 30 + 42 + 24
 }
-m 42 + 66
+m 30 + 42 + 66
 ----
 
 anchor:synobj[]

--- a/src/macro-context.js
+++ b/src/macro-context.js
@@ -306,7 +306,7 @@ export default class MacroContext {
 
   _rest(enf) {
     const priv = privateData.get(this);
-    if(priv.markers.get(priv.startMarker) === enf) {
+    if (priv.markers.get(priv.startMarker) === enf) {
       return priv.enf.rest;
     }
     throw Error("Unauthorized access!");
@@ -315,12 +315,12 @@ export default class MacroContext {
   reset(marker) {
     const priv = privateData.get(this);
     let enf;
-    if(marker == null) {
+    if (marker == null) {
       // go to the beginning
       enf = priv.markers.get(priv.startMarker);
-    } else if(marker && marker instanceof Marker) {
+    } else if (marker && marker instanceof Marker) {
       // marker could be from another context
-      if(priv.markers.has(marker)) {
+      if (priv.markers.has(marker)) {
         enf = priv.markers.get(marker);
       } else {
         throw new Error('marker must originate from this context');
@@ -334,16 +334,20 @@ export default class MacroContext {
   mark() {
     const priv = privateData.get(this);
     let marker;
-    if(priv.enf.rest.size === priv.markers.get(priv.startMarker).rest.size) {
+
+    // the idea here is that marking at the beginning shouldn't happen more than once.
+    // We can reuse startMarker.
+    if (priv.enf.rest.size === priv.markers.get(priv.startMarker).rest.size) {
       marker = priv.startMarker;
-    } else if(priv.enf.rest.isEmpty()) {
-      if(!priv.endMarker) priv.endMarker = new Marker();
+    } else if (priv.enf.rest.isEmpty()) {
+      // same reason as above
+      if (!priv.endMarker) priv.endMarker = new Marker();
       marker = priv.endMarker;
     } else {
       //TODO(optimization/dubious): check that there isn't already a marker for this index?
       marker = new Marker();
     }
-    if(!priv.markers.has(marker)) {
+    if (!priv.markers.has(marker)) {
       priv.markers.set(marker, cloneEnforester(priv.enf));
     }
     return marker;

--- a/src/macro-context.js
+++ b/src/macro-context.js
@@ -337,7 +337,7 @@ export default class MacroContext {
 
     // the idea here is that marking at the beginning shouldn't happen more than once.
     // We can reuse startMarker.
-    if (priv.enf.rest.size === priv.markers.get(priv.startMarker).rest.size) {
+    if (priv.enf.rest === priv.markers.get(priv.startMarker).rest) {
       marker = priv.startMarker;
     } else if (priv.enf.rest.isEmpty()) {
       // same reason as above

--- a/src/macro-context.js
+++ b/src/macro-context.js
@@ -319,7 +319,12 @@ export default class MacroContext {
       // go to the beginning
       enf = priv.markers.get(priv.startMarker);
     } else if(marker && marker instanceof Marker) {
-      enf = priv.markers.get(marker);
+      // marker could be from another context
+      if(priv.markers.has(marker)) {
+        enf = priv.markers.get(marker);
+      } else {
+        throw new Error('marker must originate from this context');
+      }
     } else {
       throw new Error('marker must be an instance of Marker');
     }

--- a/test/test_macro_context.js
+++ b/test/test_macro_context.js
@@ -123,6 +123,31 @@ test('a macro context should be resettable', t => {
   t.true(c1 === c2);
 });
 
+test('a macro context should be able to create a reset point', t => {
+  let enf = makeEnforester('a b c');
+  let ctx = new MacroContext(enf, Syntax.fromIdentifier('foo'), {});
+  const val = v => v.val();
+
+  let a1 = ctx.next(); // a
+
+  ctx.mark();
+
+  const [b1, c1] = [...ctx].map(val);
+  t.true(ctx.next().done);
+
+  ctx.reset();
+
+  const [b2, c2] = [...ctx].map(val);
+
+  ctx.reset();
+
+  let [a2, b3, c3] = [...ctx].map(val);
+
+  t.true(a1.value.val() === a2);
+  t.true(b1 === b2 && b2 === b3);
+  t.true(c1 === c2 && c2 === c3);
+});
+
 test('an enforester should be able to access a macro context\'s syntax list', t => {
   let enf = makeEnforester('a');
   let ctx = new MacroContext(enf, Syntax.fromIdentifier('foo'), {});

--- a/test/test_macro_context.js
+++ b/test/test_macro_context.js
@@ -130,22 +130,38 @@ test('a macro context should be able to create a reset point', t => {
 
   let a1 = ctx.next(); // a
 
-  ctx.mark();
+  const bMarker = ctx.mark();
 
-  const [b1, c1] = [...ctx].map(val);
+  const b1 = ctx.next(); // b
+
+  const cMarker = ctx.mark();
+
+  const c1 = ctx.next(); // c
+
   t.true(ctx.next().done);
 
-  ctx.reset();
+  ctx.reset(bMarker);
 
   const [b2, c2] = [...ctx].map(val);
 
+  ctx.reset(cMarker);
+
+  const c3 = ctx.next();
+
   ctx.reset();
 
-  let [a2, b3, c3] = [...ctx].map(val);
+  let [a2, b3, c4] = [...ctx].map(val);
+
+  ctx.reset(cMarker);
+
+  let c5 = ctx.next();
 
   t.true(a1.value.val() === a2);
-  t.true(b1 === b2 && b2 === b3);
-  t.true(c1 === c2 && c2 === c3);
+  t.true(b1.value.val() === b2 && b2 === b3);
+  t.true(c1.value.val() === c2 &&
+         c2 === c3.value.val() &&
+         c2 === c4 &&
+         c4 === c5.value.val());
 });
 
 test('an enforester should be able to access a macro context\'s syntax list', t => {

--- a/test/test_macro_expansion.js
+++ b/test/test_macro_expansion.js
@@ -278,6 +278,21 @@ test('should allow the macro context to create a reset point', t => {
   `, 42);
 });
 
+test('should throw if marker is from a different macro context', t => {
+  t.throws(() =>
+    testEval(`
+      syntax m = ctx => {
+        const result = ctx.next().value; // 1
+        const marker = ctx.mark();
+        ctx.next() // ,
+        const innerCtx = ctx.next().value.inner();
+        innerCtx.reset(marker);
+        return #\`\${result}\`;
+      }
+      output = m 1, [1];
+    `, 1));
+});
+
 test('should allow the macro context to match on a identifier expression', t => {
   testEval(`
     syntax m = ctx => {

--- a/test/test_macro_expansion.js
+++ b/test/test_macro_expansion.js
@@ -173,7 +173,11 @@ test('should handle the full macro context api', () => {
       let id = ctx.next().value;
       ctx.reset();
       id = ctx.next().value;
+
+      ctx.mark();
       let parens = ctx.next().value;
+      ctx.reset();
+      parens = ctx.next().value;
       let body = ctx.next().value;
 
       let parenCtx = parens.inner();
@@ -251,6 +255,26 @@ test('should allow the macro context to be reset', t => {
     }
 
     output = m 42 + 66
+  `, 42);
+});
+
+test('should allow the macro context to create a reset point', t => {
+  testEval(`
+    syntax m = ctx => {
+      ctx.next(); // 30
+      ctx.next(); // +
+      // lets play it safe
+      ctx.mark();
+      ctx.expand('expr'); // 42 + 66
+      // oops, just wanted one token
+      ctx.reset();
+      let value = ctx.next().value; // 42
+      ctx.next();
+      ctx.next();
+      return #\`\${value}\`;
+    }
+
+    output = m 30 + 42 + 66
   `, 42);
 });
 

--- a/test/test_macro_expansion.js
+++ b/test/test_macro_expansion.js
@@ -174,9 +174,9 @@ test('should handle the full macro context api', () => {
       ctx.reset();
       id = ctx.next().value;
 
-      ctx.mark();
+      const paramsMark = ctx.mark();
       let parens = ctx.next().value;
-      ctx.reset();
+      ctx.reset(paramsMark);
       parens = ctx.next().value;
       let body = ctx.next().value;
 
@@ -264,10 +264,10 @@ test('should allow the macro context to create a reset point', t => {
       ctx.next(); // 30
       ctx.next(); // +
       // lets play it safe
-      ctx.mark();
+      const marker42 = ctx.mark();
       ctx.expand('expr'); // 42 + 66
       // oops, just wanted one token
-      ctx.reset();
+      ctx.reset(marker42);
       let value = ctx.next().value; // 42
       ctx.next();
       ctx.next();


### PR DESCRIPTION
The ability to move back one term can be implemented as a utility function. Unfortunately the time complexity is O(n) in the number of syntax items.

To my mind a big reason to have this ability is to expand a term based on the type of syntax read:
```js
import { prev } from './utils' for syntax;

syntax m = ctx => {
  ctx.next() // eatThis
  let stx = ctx.next().value;
  let ret;
  if(stx.isIdentifier()) {
    ret = #`${stx}`;
  } else if(stx.isDelimiter() && stx.isBracket()) {
    prev(ctx); // <- call to prev
    ret = #`${ctx.expand('ArrayExpression')}`;
  }
  return ret;
}

m eatThis foo; // foo
m eatThis [1,2,3] // [1,2,3]
```

But the same thing can be accomplished with lookahead:
```js
import { lookahead } from './utils' for syntax;

syntax m = ctx => {
  ctx.next(); // eatThis
  let stx = lookahead(ctx); // <- call to lookahead
  let ret;
  if(stx.isIdentifier()) {
    ret = #`${stx}`;
  } else if(stx.isDelimiter() && stx.isBracket()) {
    ret = #`${ctx.expand('ArrayExpression')}`;
  }
  return ret;
}

m eatThis foo; // foo
m eatThis [1,2,3] // [1,2,3]
```
With this PR `lookahead(1)` can be implemented in constant time and `lookahead(m)` is O(m).

The feature works as follows:
```js
syntax m = ctx => {
  ctx.next(); // eatThis
  ctx.mark(); // <- marks a reset point
  let stx = ctx.next().value
  let ret;
  if(stx.isIdentifier()) {
    ret = #`${stx}`;
  } else if(stx.isDelimiter() && stx.isBracket()) {
    ctx.reset(); // <- back to reset point
    ret = #`${ctx.expand('ArrayExpression')}`;
  }
  return ret;
}

m foo; // foo
m [1,2,3] // [1,2,3]
```