### PR TITLE
Small typo fix

### DIFF
--- a/doc/1.0/tutorial.adoc
+++ b/doc/1.0/tutorial.adoc
@@ -104,7 +104,7 @@ Sweet's internal representation of syntax. Syntax objects are somewhat like toke
 == Sweet New
 
 Let's move on to a slightly more interesting example.
-Pretend you are using an OO framwork for JavaScript where instead of using `new` we want to call a `.create` method that has been monkey patched onto `Function.prototype` (don't worry, I won't judge...much). Rather than manually rewrite all usages of `new` to the `create` method you could define a macro that does it for you.
+Pretend you are using an OO framework for JavaScript where instead of using `new` we want to call a `.create` method that has been monkey patched onto `Function.prototype` (don't worry, I won't judge... much). Rather than manually rewrite all usages of `new` to the `create` method you could define a macro that does it for you.
 
 .New Macro
 [source, javascript]

--- a/doc/1.0/tutorial.html
+++ b/doc/1.0/tutorial.html
@@ -211,7 +211,7 @@ of syntax objects.</p>
 <div class="sectionbody">
 <div class="paragraph">
 <p>Let&#8217;s move on to a slightly more interesting example.
-Pretend you are using an OO framwork for JavaScript where instead of using <code>new</code> we want to call a <code>.create</code> method that has been monkey patched onto <code>Function.prototype</code> (don&#8217;t worry, I won&#8217;t judge&#8230;&#8203;much). Rather than manually rewrite all usages of <code>new</code> to the <code>create</code> method you could define a macro that does it for you.</p>
+Pretend you are using an OO framework for JavaScript where instead of using <code>new</code> we want to call a <code>.create</code> method that has been monkey patched onto <code>Function.prototype</code> (don&#8217;t worry, I won&#8217;t judge&#8230;&#8203; much). Rather than manually rewrite all usages of <code>new</code> to the <code>create</code> method you could define a macro that does it for you.</p>
 </div>
 <div class="listingblock">
 <div class="title">New Macro</div>


### PR DESCRIPTION
It’s basically `framwork -> framework`. I think I only needed to change the .adoc file, but I was not 100% sure (and I couldn’t find a _contributing.md_ file on this repo), so I just went ahead.