### PR TITLE
Enforce node version; fixes #536

### DIFF
--- a/bin/sjs
+++ b/bin/sjs
@@ -19,6 +19,12 @@ var path = require('path');
 var fs   = require('fs');
 var dir  = path.join(path.dirname(fs.realpathSync(__filename)), '../dist');
 var sweetjs = require(dir + '/sweet.js');
+var semver = require('semver');
+
+if (!semver.satisfies(process.version, '>=5.0.0')) {
+  console.log('Sweet requires node >=5.0.0, you have: ' + process.version);
+  process.exit(1);
+}
 
 argv._.forEach(function (file) {
   var infile = fs.readFileSync(file, 'utf8');

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "ramda": "^0.19.0",
     "ramda-fantasy": "^0.4.1",
     "resolve": "^1.1.7",
+    "semver": "^5.3.0",
     "shift-codegen": "^4.0.0",
     "shift-js": "^0.2.1",
     "shift-parser": "^4.1.0",


### PR DESCRIPTION
Give a nice error message and exit when using old versions of node.