### PR TITLE
Drop wrapper in macro context

### DIFF
--- a/src/load-syntax.js
+++ b/src/load-syntax.js
@@ -8,8 +8,6 @@ import SweetToShiftReducer from './sweet-to-shift-reducer';
 import TermExpander from './term-expander';
 import Env from './env';
 
-import { unwrap } from './macro-context';
-
 import { replaceTemplate } from './template-processor';
 
 export function expandCompiletime(term, context) {
@@ -34,7 +32,7 @@ export function sanitizeReplacementValues(values) {
   } else if (typeof values.next === 'function') {
     return sanitizeReplacementValues(List(values));
   }
-  return unwrap(values);
+  return values;
 }
 
 export function evalRuntimeValues(terms, context) {

--- a/test/test-asi.js
+++ b/test/test-asi.js
@@ -42,7 +42,7 @@ output = function f() {
 }().a`, 1);
 
 test(evalWithOutput, `
-syntax m = ctx => #\`return \${ctx.next().value.inner()}\`;
+syntax m = ctx => #\`return \${ctx.contextify(ctx.next().value)}\`;
 output = function f () {
   m { 1 }
 }()`, 1);

--- a/test/test-macro-context.js
+++ b/test/test-macro-context.js
@@ -1,75 +1,8 @@
 import test from 'ava';
-import MacroContext, { SyntaxOrTermWrapper } from '../src/macro-context';
+import MacroContext from '../src/macro-context';
 import Syntax from '../src/syntax';
 import { makeEnforester } from './assertions';
 import { List } from 'immutable';
-
-test('a wrapper should work with keywords', t => {
-  let kwd = Syntax.fromKeyword('foo');
-  let wrap = new SyntaxOrTermWrapper(kwd);
-  t.true(wrap.isKeyword());
-  t.true(wrap.isKeyword('foo'));
-  t.false(wrap.isKeyword('bar'));
-});
-
-test('a wrapper should work with identifiers', t => {
-  let ident = Syntax.fromIdentifier('foo');
-  let wrap = new SyntaxOrTermWrapper(ident);
-  t.true(wrap.isIdentifier());
-  t.true(wrap.isIdentifier('foo'));
-  t.false(wrap.isIdentifier('bar'));
-});
-
-test('a wrapper should work with numbers', t => {
-  let val = Syntax.fromNumber(42);
-  let wrap = new SyntaxOrTermWrapper(val);
-  t.true(wrap.isNumericLiteral());
-  t.true(wrap.isNumericLiteral(42));
-  t.false(wrap.isNumericLiteral(24));
-});
-
-test('a wrapper should work with strings', t => {
-  let val = Syntax.fromString('foo');
-  let wrap = new SyntaxOrTermWrapper(val);
-  t.true(wrap.isStringLiteral());
-  t.true(wrap.isStringLiteral('foo'));
-  t.false(wrap.isStringLiteral('bar'));
-});
-
-
-test('a wrapper should work with nulls', t => {
-  let val = Syntax.fromNull();
-  let wrap = new SyntaxOrTermWrapper(val);
-  t.true(wrap.isNullLiteral());
-});
-
-test('a wrapper should work with punctuators', t => {
-  let val = Syntax.fromPunctuator(',');
-  let wrap = new SyntaxOrTermWrapper(val);
-  t.true(wrap.isPunctuator());
-  t.true(wrap.isPunctuator(','));
-  t.false(wrap.isPunctuator('.'));
-});
-
-test('a wrapper should work with regular expressions', t => {
-  let val = Syntax.fromRegularExpression('abc');
-  let wrap = new SyntaxOrTermWrapper(val);
-  t.true(wrap.isRegularExpression());
-  t.true(wrap.isRegularExpression('abc'));
-  t.false(wrap.isRegularExpression('foo'));
-});
-
-test.skip('a wrapper should work with an inner iterator', t => {
-  let val = Syntax.fromParens(List.of(Syntax.fromIdentifier('foo'), Syntax.fromIdentifier('bar')));
-  let wrap = new SyntaxOrTermWrapper(val);
-  let ctx = wrap.inner();
-  let foo = ctx.next();
-  let bar = ctx.next();
-
-  t.true(foo.value.isIdentifier('foo'));
-  t.true(bar.value.isIdentifier('bar'));
-  t.true(ctx.next().done);
-});
 
 test.skip('a macro context should have a name', t => {
   let enf = makeEnforester('a');

--- a/test/test-macro-expansion.js
+++ b/test/test-macro-expansion.js
@@ -66,12 +66,12 @@ syntaxrec def = function(ctx) {
   parens = ctx.next().value;
   let body = ctx.next().value;
 
-  let parenCtx = parens.inner();
+  let parenCtx = ctx.contextify(parens);
   let paren_id = parenCtx.next().value;
   parenCtx.next() // =
   let paren_init = parenCtx.expand('expr').value;
 
-  let bodyCtx = body.inner();
+  let bodyCtx = ctx.contextify(body);
   let b = [];
   for (let s of bodyCtx) {
     b.push(s);
@@ -204,7 +204,7 @@ test('should construct syntax from existing syntax', evalWithOutput, `
 syntax m = ctx => {
   let arg = ctx.next().value;
   let dummy = #\`here\`.get(0);
-  return #\`\${dummy.fromString(arg.val())}\`
+  return #\`\${dummy.fromString(arg.value.val())}\`
 }
 output = m foo
 `, 'foo');
@@ -213,7 +213,7 @@ test('should construct a delimiter from existing syntax', evalWithOutput, `
 syntax m = ctx => {
   let arg = ctx.next().value;
   let dummy = #\`here\`.get(0);
-  return #\`(\${dummy.fromNumber(arg.val())})\`;
+  return #\`(\${dummy.fromNumber(arg.value.val())})\`;
 }
 output = m 1`, 1)
 


### PR DESCRIPTION
Addresses #615.

Dropping `SyntaxOrTermWrapper` and replacing its `.inner` method with a `contextify` (strawman name but I kind of like it) method on `MacroContext`.

This is doubling down on the breaking change of everything being a `Term`. 