### PR TITLE
Add support for more import/export forms

### DIFF
--- a/mod.js
+++ b/mod.js
@@ -1,4 +1,4 @@
-#lang 'base';
-export function id(x) {
-  return x;
-}
+    #lang 'base';
+    export function id(x) {
+      return x;
+    }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test": "test"
   },
   "dependencies": {
-    "sweet-spec": "3.0.0-pre.1",
+    "sweet-spec": "3.0.0-pre.2",
     "babel-core": "^6.18.0",
     "immutable": "^3.7.4",
     "ramda": "^0.22.0",

--- a/src/sweet-module.js
+++ b/src/sweet-module.js
@@ -1,37 +1,109 @@
 // @flow
+import * as T from 'sweet-spec';
 import * as _ from 'ramda';
-import Term, * as S from 'sweet-spec';
+import * as S from './sweet-spec-utils';
 import codegen from './codegen';
 import { List } from 'immutable';
 import SweetToShiftReducer from './sweet-to-shift-reducer.js';
-import * as T from './terms';
+import Syntax from './syntax';
 
+const extractDeclaration = _.cond([
+  [S.isExport,        _.prop('declaration')],
+  [S.isExportDefault, _.prop('body')],
+  [_.T,               term => { throw new Error(`Expecting an Export or ExportDefault but got ${term}`) }]
+]);
+
+const extractDeclarationNames = _.cond([
+  [S.isVariableDeclarator, decl => List.of(decl.binding.name)],
+  [S.isVariableDeclaration, decl => decl.declarators.flatMap(extractDeclarationNames)],
+  [S.isFunctionDeclaration, decl => List.of(decl.name.name)],
+  [S.isClassDeclaration, decl => List.of(decl.name.name)]
+]);
+
+function extractNames(term: T.ExportDeclaration): List<Syntax> {
+  if (S.isExport(term)) {
+    return extractDeclarationNames(term.declaration);  
+  } else if (S.isExportDefault(term)) {
+    return List(); 
+  } else if (S.isExportFrom(term)) {
+    return List();    
+  }
+  throw new Error(`Unknown export type`);
+}
+
+function wrapStatement(declaration: T.Term) {
+  if (S.isVariableDeclaration(declaration)) {
+    return new T.VariableDeclarationStatement({ declaration });
+  }
+  return declaration;
+}
+
+const memoSym = Symbol('memo');
 
 export default class SweetModule {
-  items: List<Term>;
+  items: List<T.Term>;
+  imports: List<T.ImportDeclaration>;
+  exports: List<T.ExportDeclaration>;
+  exportedNames: List<Syntax>;
 
-  constructor(items: List<Term>) {
-    this.items = items;
+  runtime: List<T.Term>;
+  compiletime: List<T.Term>;
+
+  constructor(items: List<T.Term>) {
+    let body = [];
+    let imports = [];
+    let exports = [];
+    this.exportedNames = List();
+    for (let item of items) {
+      if (S.isImportDeclaration(item)) {
+        imports.push(item);
+      } else if (S.isExportDeclaration(item)) {
+        exports.push(item);
+        this.exportedNames = this.exportedNames.concat(extractNames(item));
+        if (S.isExport(item) || S.isExportDefault(item)) {
+          body.push(wrapStatement(extractDeclaration(item))); 
+        }
+      } else {
+        body.push(item);
+      }
+    }
+    this.items = List(body);
+    this.imports = List(imports);
+    this.exports = List(exports);
+  }
+
+  // $FlowFixMe: flow doesn't support computed property keys yet
+  [memoSym]() {
+    let runtime = [], compiletime = [];
+    for (let item of this.items) {
+      if (S.isCompiletimeStatement(item)) {
+        compiletime.push(item);
+      } else {
+        runtime.push(item);
+      }
+    }
+    this.runtime = List(runtime);
+    this.compiletime = List(compiletime);
   }
 
   runtimeItems() {
-    return this.items.filter(_.complement(T.isCompiletimeStatement));
+    if (this.runtime == null) {
+      // $FlowFixMe: flow doesn't support computed property keys yet
+      this[memoSym]();
+    }
+    return this.runtime;
   }
 
   compiletimeItems() {
-    return this.items.filter(T.isCompiletimeStatement);
-  }
-
-  importEntries() {
-    return this.items.filter(T.isImportDeclaration);
-  }
-
-  exportEntries() {
-    return this.items.filter(T.isExportDeclaration);
+    if (this.compiletime == null) {
+      // $FlowFixMe: flow doesn't support computed property keys yet
+      this[memoSym]();
+    }
+    return this.compiletime;
   }
 
   parse() {
-    return new S.Module({
+    return new T.Module({
       items: this.items,
       directives: List()
     }).reduce(new SweetToShiftReducer(0));

--- a/src/sweet-spec-utils.js
+++ b/src/sweet-spec-utils.js
@@ -1,0 +1,31 @@
+// @flow
+
+import * as T from 'sweet-spec';
+import * as _ from 'ramda';
+
+export const isImportDeclaration = _.is(T.ImportDeclaration);
+
+export const isExportDeclaration = _.is(T.ExportDeclaration);
+export const isExport = _.is(T.Export);
+export const isExportDefault = _.is(T.ExportDefault);
+export const isExportFrom = _.is(T.ExportFrom);
+
+export const isVariableDeclaration = _.is(T.VariableDeclaration);
+export const isVariableDeclarator = _.is(T.VariableDeclarator);
+export const isSyntaxVariableDeclartion = _.both(
+  isVariableDeclaration, 
+  _.either(_.propEq('kind', 'syntax'),
+           _.propEq('kind', 'syntaxrec')) 
+);
+
+export const isVariableDeclarationStatement = _.is(T.VariableDeclarationStatement);
+export const isSyntaxDeclarationStatement = (term: any) => {
+  // syntax m = ...
+  // syntaxrec m = ...
+  return isVariableDeclarationStatement(term) && isSyntaxVariableDeclartion(term.declaration);
+}
+
+export const isCompiletimeStatement = isSyntaxDeclarationStatement;
+
+export const isFunctionDeclaration = _.is(T.FunctionDeclaration);
+export const isClassDeclaration = _.is(T.ClassDeclaration);

--- a/src/token-expander.js
+++ b/src/token-expander.js
@@ -86,11 +86,12 @@ function bindImports(impTerm: S.ImportDeclaration, exModule: SweetModule, contex
   let phase = impTerm.forSyntax ? context.phase + 1 : context.phase;
   impTerm.namedImports.forEach(specifier => {
     let name = specifier.binding.name;
-    let exportName = exModule.exportedNames.find(exName => exName.val() === name.val());
+    let exportName = exModule.exportedNames.find(exName => exName.exportedName.val() === name.val());
     if (exportName != null) {
       let newBinding = gensym(name.val());
+      let toForward = exportName.name ? exportName.name : exportName.exportedName;
       context.store.set(newBinding.toString(), new VarBindingTransform(name));
-      context.bindings.addForward(name, exportName, newBinding, phase);
+      context.bindings.addForward(name, toForward, newBinding, phase);
       names.push(name);
     }
   });

--- a/src/token-expander.js
+++ b/src/token-expander.js
@@ -95,6 +95,17 @@ function bindImports(impTerm: S.ImportDeclaration, exModule: SweetModule, contex
       names.push(name);
     }
   });
+  if (impTerm.defaultBinding != null) {
+    let exportName = exModule.exportedNames.find(exName => exName.exportedName.val() === '_default');
+    let name = impTerm.defaultBinding.name;
+    if (exportName != null) {
+      let newBinding = gensym('_default');
+      let toForward = exportName.exportedName;
+      context.store.set(newBinding.toString(), new VarBindingTransform(name));
+      context.bindings.addForward(name, toForward, newBinding, phase);
+      names.push(name);
+    }
+  }
   return List(names);
 }
 

--- a/src/transforms.js
+++ b/src/transforms.js
@@ -1,3 +1,7 @@
+// @flow
+import SweetModule from './sweet-module';
+import Syntax from './syntax';
+
 export class FunctionDeclTransform { }
 export class VariableDeclTransform { }
 export class NewTransform { }
@@ -17,13 +21,26 @@ export class DebuggerTransform { }
 export class SyntaxrecDeclTransform { }
 export class SyntaxDeclTransform { }
 export class ReturnStatementTransform { }
+export class ModuleNamespaceTransform {
+  namespace: Syntax;
+  mod: SweetModule;
+
+  constructor(namespace: Syntax, mod: SweetModule) {
+    this.namespace = namespace;
+    this.mod = mod;
+  }
+}
 export class VarBindingTransform {
-  constructor(id) {
+  id: Syntax;
+  
+  constructor(id: Syntax) {
     this.id = id;
   }
 }
 export class CompiletimeTransform {
-  constructor(value) {
+  value: any;
+
+  constructor(value: any) {
     this.value = value;
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,1 +1,6 @@
-a + b - c
+    import { id } from './mod.js' for syntax;
+
+    syntax m = ctx => {
+      return id(#`1`);
+    }
+    output = m;

--- a/test/test-modules.js
+++ b/test/test-modules.js
@@ -107,6 +107,34 @@ test('importing a macro for syntax only binds what is named', evalWithStore, {
   `
   }, 1);
 
+  test('exporting names for syntax', evalWithStore, {
+'./mod.js': `
+function id(x) { return x; }
+export { id }  
+`,
+'main.js': `
+import { id } from './mod.js' for syntax;
+syntax m = ctx => {
+  return id(#\`1\`);
+}
+output = m
+`
+  }, 1)
+
+  test('exporting names with renaming for syntax', evalWithStore, {
+'./mod.js': `
+function id(x) { return x; }
+export { id as di }  
+`,
+'main.js': `
+import { di } from './mod.js' for syntax;
+syntax m = ctx => {
+  return di(#\`1\`);
+}
+output = m
+`
+  }, 1)
+
 // test('importing a chain for syntax works', evalWithStore, {
 //   'b': `#lang 'sweet.js';
 //     export function b(x) { return x; }

--- a/test/test-modules.js
+++ b/test/test-modules.js
@@ -148,6 +148,17 @@ output = m
 `
   }, 1)
 
+  test('importing a namespace for syntax', evalWithStore, {
+'./mod.js': `
+export function id(x) { return x; }`,
+'main.js': `
+import * as M from './mod.js' for syntax;
+syntax m = ctx => {
+  return M.id(#\`1\`);
+}
+output = m`
+  }, 1)
+
 // test('importing a chain for syntax works', evalWithStore, {
 //   'b': `#lang 'sweet.js';
 //     export function b(x) { return x; }

--- a/test/test-modules.js
+++ b/test/test-modules.js
@@ -135,6 +135,19 @@ output = m
 `
   }, 1)
 
+  test('exporting default names for syntax', evalWithStore, {
+'./mod.js': `
+export default function id(x) { return x; }
+`,
+'main.js': `
+import id from './mod.js' for syntax;
+syntax m = ctx => {
+  return id(#\`1\`);
+}
+output = m
+`
+  }, 1)
+
 // test('importing a chain for syntax works', evalWithStore, {
 //   'b': `#lang 'sweet.js';
 //     export function b(x) { return x; }


### PR DESCRIPTION
This PR does some more refactoring of the module handling code and adds support for:

- default imports/exports
- export specifiers with renaming (e.g. `var x = 1; export { x as y }`)
- import namespaces (`import * as T`)