### PR TITLE
Add ability to select extensions to resolve

### DIFF
--- a/src/node-loader.js
+++ b/src/node-loader.js
@@ -7,9 +7,11 @@ import vm from 'vm';
 import Store from './store';
 
 export default class NodeLoader extends SweetLoader {
+  extensions: ?string[];
 
-  constructor(baseDir: string) {
+  constructor(baseDir: string, extensions?: string[]) {
     super(baseDir);
+    this.extensions = extensions;
   }
 
   normalize(name: string, refererName?: string, refererAddress?: string) {
@@ -17,7 +19,8 @@ export default class NodeLoader extends SweetLoader {
     let match = normName.match(phaseInModulePathRegexp);
     if (match && match.length >= 3) {
       let resolvedName = resolve.sync(match[1], {
-        basedir: refererName ? dirname(refererName) : this.baseDir
+        basedir: refererName ? dirname(refererName) : this.baseDir,
+        extensions: this.extensions ? this.extensions : [ '.js' ]
       });
       return `${resolvedName}:${match[2]}`;
     }


### PR DESCRIPTION
By default `resolve` only looks for files with `.js` as an extension. This adds the ability for the `NodeLoader` to enable additional extensions to resolve.

