### PR TITLE
Add console and process to global in a macro definition

### DIFF
--- a/src/node-loader.js
+++ b/src/node-loader.js
@@ -39,7 +39,11 @@ export default class NodeLoader extends SweetLoader {
   }
 
   freshStore() {
-    return new Store(vm.createContext());
+    let sandbox = {
+      process: global.process,
+      console: global.console
+    };
+    return new Store(vm.createContext(sandbox));
   }
 
   eval(source: string, store: Store) {


### PR DESCRIPTION
Enables:

```js
syntax m = ctx => {
  console.log(process.env);
  return #`1`;
}
m
```