### PR TITLE
Simplify prefix so only TokenTree is used

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,19 +87,7 @@
   "ava": {
     "babel": "inherit",
     "files": [
-      "test/test-sweet-loader.js",
-      "test/test-macro-expansion.js",
-      "test/test-hygiene.js",
-      "test/test-asi.js",
-      "test/test-modules.js",
-      "test/test-syntax.js",
-      "test/test-symbols.js",
-      "test/test-run-test262.js",
-      "test/test-char-stream.js",
-      "test/test-readtable.js",
-      "test/test-default-readtable.js",
-      "test/test-macro-context.js",
-      "test/test-reader-extensions.js"
+      "test/test-default-readtable.js"
     ],
     "require": [
       "babel-register"

--- a/src/reader/default-readtable.js
+++ b/src/reader/default-readtable.js
@@ -151,13 +151,13 @@ const bracesEntry = {
   mode: 'terminating',
   action: function readBraces(stream, prefix, b) {
     const line = this.locationInfo.line;
-    const innerB = isExprPrefix(line, b)(prefix);
+    const innerB = isExprPrefix(line, b, prefix);
     return readDelimiters.call(this, '}', stream, prefix, innerB);
   }
 };
 
 function readClosingDelimiter(opening, closing, stream, prefix, b) {
-  if (prefix.first().token.value !== opening) {
+  if (prefix.first().value !== opening) {
     throw Error('Unmatched delimiter:', closing);
   }
   return readPunctuator.call(this, stream);
@@ -180,7 +180,7 @@ const divEntry = {
       const result = readComment.call(this, stream);
       return result;
     }
-    if (isRegexPrefix(b)(prefix)) {
+    if (isRegexPrefix(b, prefix)) {
       return readRegExp.call(this, stream, prefix, b);
     }
     return readPunctuator.call(this, stream);

--- a/src/reader/read-dispatch.js
+++ b/src/reader/read-dispatch.js
@@ -41,12 +41,13 @@ export function readSyntaxTemplate(stream: CharStream, prefix: List<any>, exprAl
   return result;
 }
 
-function updateSyntax(prefix, token) {
-
-  token.value = prefix + token.value;
-  token.slice.text = prefix + token.slice.text;
-  token.slice.start -= 1;
-  token.slice.startLocation.position -= 1;
-
-  return token;
+function updateSyntax(prefix, term) {
+  if (term.value) {
+    let token = term.value;
+    token.value = prefix + token.value;
+    token.slice.text = prefix + token.slice.text;
+    token.slice.start -= 1;
+    token.slice.startLocation.position -= 1;
+  }
+  return term;
 }

--- a/src/reader/read-dispatch.js
+++ b/src/reader/read-dispatch.js
@@ -3,14 +3,13 @@
 import { getCurrentReadtable, setCurrentReadtable } from './reader';
 import { LSYNTAX, RSYNTAX } from './utils';
 import { List } from 'immutable';
-import Syntax from '../syntax';
 
 import type CharStream from './char-stream';
 
 const backtickEntry = {
   key: '`',
   mode: 'terminating',
-  action: function readBacktick(stream: CharStream, prefix: List<Syntax>, e: boolean) {
+  action: function readBacktick(stream: CharStream, prefix: List<any>, e: boolean) {
     if (prefix.isEmpty()) {
       return {
         type: LSYNTAX,
@@ -25,7 +24,7 @@ const backtickEntry = {
   }
 };
 
-export function readSyntaxTemplate(stream: CharStream, prefix: List<Syntax>, exprAllowed: boolean, dispatchChar: string): List<Syntax> | { type: typeof RSYNTAX, value: string } {
+export function readSyntaxTemplate(stream: CharStream, prefix: List<any>, exprAllowed: boolean, dispatchChar: string): List<any> | { type: typeof RSYNTAX, value: string } {
   // return read('syntaxTemplate').first().token;
   // TODO: Can we simply tack 'syntaxTemplate' on the front and process it as a
   //       syntax macro?
@@ -42,13 +41,12 @@ export function readSyntaxTemplate(stream: CharStream, prefix: List<Syntax>, exp
   return result;
 }
 
-function updateSyntax(prefix, syntax) {
-  const token = syntax.token;
+function updateSyntax(prefix, token) {
 
   token.value = prefix + token.value;
   token.slice.text = prefix + token.slice.text;
   token.slice.start -= 1;
   token.slice.startLocation.position -= 1;
 
-  return syntax;
+  return token;
 }

--- a/src/reader/read-dispatch.js
+++ b/src/reader/read-dispatch.js
@@ -41,13 +41,10 @@ export function readSyntaxTemplate(stream: CharStream, prefix: List<any>, exprAl
   return result;
 }
 
-function updateSyntax(prefix, term) {
-  if (term.value) {
-    let token = term.value;
-    token.value = prefix + token.value;
-    token.slice.text = prefix + token.slice.text;
-    token.slice.start -= 1;
-    token.slice.startLocation.position -= 1;
-  }
-  return term;
+function updateSyntax(prefix, token) {
+  token.value = prefix + token.value;
+  token.slice.text = prefix + token.slice.text;
+  token.slice.start -= 1;
+  token.slice.startLocation.position -= 1;
+  return token;
 }

--- a/src/reader/read-template.js
+++ b/src/reader/read-template.js
@@ -2,14 +2,13 @@
 import { List } from 'immutable';
 
 import type CharStream from './char-stream';
-import type Syntax from '../syntax';
 
 import { isEOS } from './char-stream';
 import { readStringEscape } from './utils';
 import { getSlice } from './token-reader';
 import { TemplateToken, TemplateElementToken } from '../tokens';
 
-export default function readTemplateLiteral(stream: CharStream, prefix: List<Syntax>): TemplateToken {
+export default function readTemplateLiteral(stream: CharStream, prefix: List<any>): TemplateToken {
   let element, items = [];
   stream.readString();
 

--- a/src/reader/reader.js
+++ b/src/reader/reader.js
@@ -20,7 +20,7 @@ let currentReadtable = EmptyReadtable.extend({
 });
 
 export default class Reader {
-  read(stream: CharStream, ...rest?: Array<any>): any {
+  read(stream: CharStream, ...rest?: Array<any>) {
     let key = stream.peek();
     if (!isEOS(key)) {
       const entry = currentReadtable.getMapping(key);

--- a/src/reader/token-reader.js
+++ b/src/reader/token-reader.js
@@ -5,7 +5,6 @@ import defaultReadtable from './default-readtable';
 import { List } from 'immutable';
 import CharStream, { isEOS } from './char-stream';
 import { EmptyToken } from '../tokens';
-import Syntax from '../syntax';
 
 import type { StartLocation, Slice } from '../tokens';
 
@@ -71,7 +70,7 @@ class TokenReader extends Reader {
     : this.createError('Unexpected end of input');
   }
 
-  readToken(stream: CharStream, ...rest: Array<any>): Syntax {
+  readToken(stream: CharStream, ...rest: Array<any>) {
     const startLocation = Object.assign({}, this.locationInfo, stream.sourceInfo);
     const result = super.read(stream, ...rest);
 
@@ -84,10 +83,10 @@ class TokenReader extends Reader {
 
     if (!List.isList(result)) result.slice = getSlice(stream, startLocation);
 
-    return new Syntax(result, this.context);
+    return result;
   }
 
-  readUntil(close: ?Function | ?string, stream: CharStream, results: List<Syntax>, exprAllowed: boolean): List<Syntax> {
+  readUntil(close: ?Function | ?string, stream: CharStream, results: List<any>, exprAllowed: boolean): List<any> {
     let result, done = false;
     do {
       if (isEOS(stream.peek())) break;
@@ -107,7 +106,7 @@ class TokenReader extends Reader {
   }
 }
 
-export default function read(source: string | CharStream, context?: Context): List<Syntax> {
+export default function read(source: string | CharStream, context?: Context): List<any> {
   const stream = (typeof source === 'string') ? new CharStream(source) : source;
   if (isEOS(stream.peek())) return List();
   return new TokenReader(stream, context).readUntil(null, stream, List(), false);

--- a/src/reader/token-reader.js
+++ b/src/reader/token-reader.js
@@ -95,7 +95,7 @@ class TokenReader extends Reader {
       result = this.readToken(stream, prefix, exprAllowed);
 
       if (result !== EmptyToken) {
-        prefix = prefix.push(result);
+        prefix = prefix.push(unwrapToken(result));
         results = results.push(wrapToken(result));
       }
     } while(!done);
@@ -106,6 +106,13 @@ class TokenReader extends Reader {
     this.locationInfo.line += 1;
     this.locationInfo.column = 1;
   }
+}
+
+function unwrapToken(tok: List<T.SyntaxTerm>) {
+  if (List.isList(tok)) {
+    return List.of(tok.first().value, tok.last().value);
+  }
+  return tok;
 }
 
 function wrapToken(t) {

--- a/src/reader/token-reader.js
+++ b/src/reader/token-reader.js
@@ -4,7 +4,9 @@ import Reader, { setCurrentReadtable } from './reader';
 import defaultReadtable from './default-readtable';
 import { List } from 'immutable';
 import CharStream, { isEOS } from './char-stream';
-import { EmptyToken } from '../tokens';
+import { EmptyToken, getKind } from '../tokens';
+import * as T from 'sweet-spec';
+import Syntax from '../syntax';
 
 import type { StartLocation, Slice } from '../tokens';
 
@@ -81,9 +83,16 @@ class TokenReader extends Reader {
 
     if (result === EmptyToken) return result;
 
-    if (!List.isList(result)) result.slice = getSlice(stream, startLocation);
-
-    return result;
+    if (List.isList(result)) {
+      return new T.RawDelimiter({
+        kind: getKind(result),
+        inner: result
+      });
+    }
+    result.slice = getSlice(stream, startLocation);
+    return new T.RawSyntax({
+      value: new Syntax(result)
+    });
   }
 
   readUntil(close: ?Function | ?string, stream: CharStream, results: List<any>, exprAllowed: boolean): List<any> {

--- a/src/reader/token-reader.js
+++ b/src/reader/token-reader.js
@@ -6,7 +6,6 @@ import { List } from 'immutable';
 import CharStream, { isEOS } from './char-stream';
 import { EmptyToken, getKind } from '../tokens';
 import * as T from 'sweet-spec';
-import Syntax from '../syntax';
 
 import type { StartLocation, Slice } from '../tokens';
 
@@ -83,27 +82,21 @@ class TokenReader extends Reader {
 
     if (result === EmptyToken) return result;
 
-    if (List.isList(result)) {
-      return new T.RawDelimiter({
-        kind: getKind(result),
-        inner: result
-      });
-    }
-    result.slice = getSlice(stream, startLocation);
-    return new T.RawSyntax({
-      value: new Syntax(result)
-    });
+    if (!List.isList(result)) result.slice = getSlice(stream, startLocation);
+
+    return result;
   }
 
-  readUntil(close: ?Function | ?string, stream: CharStream, results: List<any>, exprAllowed: boolean): List<any> {
-    let result, done = false;
+  readUntil(close: ?Function | ?string, stream: CharStream, prefix: List<any>, exprAllowed: boolean): List<any> {
+    let result, results = prefix.map(wrapToken), done = false;
     do {
       if (isEOS(stream.peek())) break;
       done = typeof close === 'function' ? close() : stream.peek() === close;
-      result = this.readToken(stream, results, exprAllowed);
+      result = this.readToken(stream, prefix, exprAllowed);
 
       if (result !== EmptyToken) {
-        results = results.push(result);
+        prefix = prefix.push(result);
+        results = results.push(wrapToken(result));
       }
     } while(!done);
     return results;
@@ -113,6 +106,18 @@ class TokenReader extends Reader {
     this.locationInfo.line += 1;
     this.locationInfo.column = 1;
   }
+}
+
+function wrapToken(t) {
+  if (List.isList(t)) {
+    return new T.RawDelimiter({
+      kind: getKind(t),
+      inner: t
+    });
+  }
+  return new T.RawSyntax({
+    value: t
+  });
 }
 
 export default function read(source: string | CharStream, context?: Context): List<any> {

--- a/src/reader/utils.js
+++ b/src/reader/utils.js
@@ -1,11 +1,15 @@
 // @flow
 
 import { isEOS } from './char-stream';
+import { List } from 'immutable';
 
 import type CharStream from './char-stream';
 import type Readtable from './readtable';
 
 import { code  } from 'esutils';
+import type { TokenTree } from '../tokens';
+import { getLineNumber, isPunctuator, isKeyword, isBraces, isParens, isIdentifier } from '../tokens';
+
 const { isLineTerminator,
         isWhiteSpace,
         isDecimalDigit,
@@ -14,7 +18,6 @@ const { isLineTerminator,
 
 import * as R from 'ramda';
 import { Maybe } from 'ramda-fantasy';
-const Just = Maybe.Just;
 const Nothing = Maybe.Nothing;
 
 export const LSYNTAX = { name: 'left-syntax' };
@@ -214,10 +217,6 @@ export function retrieveSequenceLength(table: Object, stream: CharStream, idx: n
   }
 }
 
-// const isEOS = R.whereEq({ type: TokenType.EOS });
-
-// const isHash = R.whereEq({ type: TokenType.IDENTIFIER, value: '#'});
-
 const assignOps =  ['=', '+=', '-=', '*=', '/=', '%=', '<<=', '>>=', '>>>=',
                   '&=', '|=', '^=', ','];
 
@@ -227,197 +226,203 @@ const binaryOps = ['+', '-', '*', '/', '%','<<', '>>', '>>>', '&', '|', '^',
 
 const unaryOps = ['++', '--', '~', '!', 'delete', 'void', 'typeof', 'yield', 'throw', 'new'];
 
-// List -> Boolean
-const isEmpty = R.whereEq({size: 0});
+const allOps = assignOps.concat(binaryOps).concat(unaryOps);
 
-// Syntax -> Boolean
-const isPunctuator = s => s.match('punctuator');
-const isKeyword = s => s.match('keyword');
-const isParens = s => s.match('parens');
-const isBraces = s => s.match('braces');
-const isIdentifier = s => s.match('identifier');
+function isNonLiteralKeyword(t: TokenTree) {
+  return isKeyword(t) && t.value && !R.contains(t.value, literalKeywords);
+}
+const exprPrefixKeywords = ['instanceof', 'typeof', 'delete', 'void',
+                            'yield', 'throw', 'new', 'case'];
 
-// Any -> Syntax -> Boolean
-const isVal = R.curry((v, s) => s.val() === v);
-
-// Syntax -> Boolean
-const isDot = R.allPass([isPunctuator, isVal('.')]);
-const isColon = R.allPass([isPunctuator, isVal(':')]);
-const isFunctionKeyword = R.allPass([isKeyword, isVal('function')]);
-const isOperator = s => (s.match('punctuator') || s.match('keyword')) &&
-                          R.any(R.equals(s.val()),
-                                assignOps.concat(binaryOps).concat(unaryOps));
-const isNonLiteralKeyword = R.allPass([isKeyword,
-                                       s => R.none(R.equals(s.val()), literalKeywords)]);
-const isKeywordExprPrefix = R.allPass([isKeyword,
-  s => R.any(R.equals(s.val()), ['instanceof', 'typeof', 'delete', 'void',
-                                  'yield', 'throw', 'new', 'case'])]);
-// List a -> a?
-let last = p => p.last();
-// List a -> Maybe a
-let safeLast = R.pipe(R.cond([
-  [isEmpty, R.always(Nothing())],
-  [R.T, R.compose(Maybe.of, last)]
-]));
-
-// TODO: better name (areTrue & areFalse)?
-// List -> Boolean -> Maybe List
-let stuffTrue = R.curry((p, b) => b ? Just(p) : Nothing());
-let stuffFalse = R.curry((p, b) => !b ? Just(p) : Nothing());
-
-// List a -> Boolean
-let isTopColon = R.pipe(
-  safeLast,
-  R.map(isColon),
-  Maybe.maybe(false, R.identity)
-);
-// List a -> Boolean
-let isTopPunctuator = R.pipe(
-  safeLast,
-  R.map(isPunctuator),
-  Maybe.maybe(false, R.identity)
-);
-
-// Number -> List -> Boolean
-let isExprReturn = R.curry((l, p) => {
-  let retKwd = safeLast(p);
-  let maybeDot = pop(p).chain(safeLast);
-
-  if (maybeDot.map(isDot).getOrElse(false)) {
-    return true;
-  }
-  return retKwd.map(s => {
-    return s.match('keyword') && s.val() === 'return' && s.lineNumber() === l;
-  }).getOrElse(false);
-});
-
-const isTopOperator = R.pipe(
-  safeLast,
-  R.map(isOperator),
-  Maybe.maybe(false, R.identity)
-);
-
-const isTopKeywordExprPrefix = R.pipe(
-  safeLast,
-  R.map(isKeywordExprPrefix),
-  Maybe.maybe(false, R.identity)
-);
-
-// Number -> Boolean -> List -> Boolean
-export let isExprPrefix = R.curry((l, b) => R.cond([
-  // ... ({x: 42} /r/i)
-  [isEmpty, R.always(b)],
-  // ... ({x: {x: 42} /r/i })
-  [isTopColon, R.always(b)],
-  // ... throw {x: 42} /r/i
-  [isTopKeywordExprPrefix, R.T],
-  // ... 42 + {x: 42} /r/i
-  [isTopOperator, R.T],
-  // ... for ( ; {x: 42}/r/i)
-  [isTopPunctuator, R.always(b)],
+function isExprReturn(l: number, p: List<TokenTree>) {
   // ... return {x: 42} /r /i
   // ... return\n{x: 42} /r /i
-  [isExprReturn(l), R.T],
-  [R.T, R.F],
-]));
-
-// List a -> Maybe List a
-let curly = p => safeLast(p).map(isBraces).chain(stuffTrue(p));
-let paren = p => safeLast(p).map(isParens).chain(stuffTrue(p));
-let func = p => safeLast(p).map(isFunctionKeyword).chain(stuffTrue(p));
-let ident = p => safeLast(p).map(isIdentifier).chain(stuffTrue(p));
-let nonLiteralKeyword = p => safeLast(p).map(isNonLiteralKeyword).chain(stuffTrue(p));
-
-let opt = R.curry((a, b, p) => {
-  let result = R.pipeK(a, b)(Maybe.of(p));
-  return Maybe.isJust(result) ? result : Maybe.of(p);
-});
-
-let notDot = R.ifElse(
-  R.whereEq({size: 0}),
-  Just,
-  p => safeLast(p).map(s => !(s.match('punctuator') && s.val() === '.')).chain(stuffTrue(p))
-);
-
-// List a -> Maybe List a
-let pop = R.compose(Just, p => p.pop());
-
-// Maybe List a -> Maybe List a
-const functionPrefix = R.pipeK(
-    curly,
-    pop,
-    paren,
-    pop,
-    opt(ident, pop),
-    func);
-
-// Boolean -> List a -> Boolean
-export const isRegexPrefix = (exprAllowed: boolean) => R.anyPass([
-  // ε
-  isEmpty,
-  // P . t   where t ∈ Punctuator
-  isTopPunctuator,
-  // P . t . t'  where t \not = "." and t' ∈ (Keyword \setminus  LiteralKeyword)
-  R.pipe(
-    Maybe.of,
-    R.pipeK(
-      nonLiteralKeyword,
-      pop,
-      notDot
-    ),
-    Maybe.isJust
-  ),
-  // P . t . t' . (T)  where t \not = "." and t' ∈ (Keyword \setminus LiteralKeyword)
-  R.pipe(
-    Maybe.of,
-    R.pipeK(
-      paren,
-      pop,
-      nonLiteralKeyword,
-      pop,
-      notDot
-    ),
-    Maybe.isJust
-  ),
-  // P . function^l . x? . () . {}     where isExprPrefix(P, b, l) = false
-  R.pipe(
-    Maybe.of,
-    functionPrefix,
-    R.chain(p => {
-        return safeLast(p)
-          .map(s => s.lineNumber())
-          .chain(fnLine => {
-            return pop(p).map(isExprPrefix(fnLine, exprAllowed));
-          })
-          .chain(stuffFalse(p));
+  return popRestMaybe(p)
+    .chain(([retKwd, rest]) => {
+      if (isKeyword(retKwd, 'return') && getLineNumber(retKwd) === l) {
+        return popRestMaybe(rest);
       }
-    ),
-    Maybe.isJust
-  ),
-  // P . {T}^l  where isExprPrefix(P, b, l) = false
-  p => {
-    let alreadyCheckedFunction = R.pipe(
-      Maybe.of,
-      functionPrefix,
-      Maybe.isJust
-    )(p);
-    if (alreadyCheckedFunction) {
-      return false;
-    }
-    return R.pipe(
-      Maybe.of,
-      R.chain(curly),
-      R.chain(p => {
-        return safeLast(p)
-        .map(s => s.lineNumber())
-        .chain(curlyLine => {
-          return pop(p).map(isExprPrefix(curlyLine, exprAllowed));
-        })
-        .chain(stuffFalse(p));
-      }),
-      Maybe.isJust
-    )(p);
+      return Nothing();
+    })
+    .map(([dot, rest]) => {
+      return isPunctuator(dot, '.');
+    }).getOrElse(false);
+}
+
+// List a -> Boolean
+function isTopPunctuator(p: List<TokenTree>) {
+  return popMaybe(p)
+    .map(punc => isPunctuator(punc))
+    .getOrElse(false);
+}
+
+function isOperator(op: TokenTree) {
+  if ((isPunctuator(op) || isKeyword(op)) && op.value != null) {
+    const opVal = op.value;  // the const is because flow doesn't know op.value isn't mutated
+    return allOps.some(o => o === opVal);
   }
+  return false;
+}
+
+function isTopOperator(p: List<TokenTree>) {
+  return popMaybe(p)
+    .map(op => {
+      return isOperator(op);
+    }).getOrElse(false);
+}
+
+function isExprPrefixKeyword(kwd: TokenTree) {
+  return isKeyword(kwd, exprPrefixKeywords);
+}
+
+function isTopKeywordExprPrefix(p: List<TokenTree>) {
+  return popMaybe(p)
+    .map(kwd => {
+      return isExprPrefixKeyword(kwd);
+    }).getOrElse(false);
+}
+
+function isTopColon(p: List<TokenTree>) {
+  return popMaybe(p)
+    .map(colon => {
+      if (isPunctuator(colon, ':')) {
+        return true;
+      }
+      return false;
+    }).getOrElse(false);
+}
+
+export function isExprPrefix(l: number, b: boolean, p: List<TokenTree>) {
+  if (p.size === 0) {
+    // ... ({x: 42} /r/i)
+    return b;
+  } else if (isTopColon(p)) {
+    // ... ({x: {x: 42} /r/i })
+    return b;
+  } else if (isTopKeywordExprPrefix(p)) {
+    // ... throw {x: 42} /r/i
+    return true;
+  } else if (isTopOperator(p)) {
+    // ... 42 + {x: 42} /r/i
+    return true;
+  } else if (isTopPunctuator(p)) {
+    // ... for ( ; {x: 42}/r/i)
+    return b;
+  } else if (isExprReturn(l, p)) {
+    // ... return {x: 42} /r /i
+    // ... return\n{x: 42} /r /i
+    return true;
+  }
+  return false;
+}
+
+function popMaybe<T>(p: List<T>): Maybe<T> {
+  if (p.size >= 1) {
+    return Maybe.of(p.last());
+  }
+  return Nothing();
+}
+
+function isTopStandaloneKeyword(prefix: List<TokenTree>) {
+    // P . t . t'  where t \not = "." and t' ∈ (Keyword \setminus  LiteralKeyword)
+  return popRestMaybe(prefix)
+    .map(([kwd, rest]) => {
+      if (isNonLiteralKeyword(kwd)) {
+        return Maybe.maybe(true, dot => !isPunctuator(dot, '.'), popMaybe(rest));
+      }
+      return false;
+    }).getOrElse(false);
+}
+
+function isTopParensWithKeyword(prefix: List<TokenTree>) {
+  // P . t . t' . (T)  where t \not = "." and t' ∈ (Keyword \setminus LiteralKeyword)
+  return popRestMaybe(prefix)
+    .chain(([paren, rest]) => isParens(paren) ? popRestMaybe(rest) : Nothing())
+    .map(([kwd, rest]) => {
+      if (isNonLiteralKeyword(kwd)) {
+        return Maybe.maybe(true, dot => !isPunctuator(dot, '.'), popMaybe(rest));
+      }
+      return false;
+    }).getOrElse(false);
+}
 
 
-]);
+function popRestMaybe(p: List<TokenTree>): Maybe<[TokenTree, List<TokenTree>]> {
+  if (p.size > 0) {
+    let last = p.last();
+    let rest = p.pop();
+    return Maybe.of([last, rest]);
+  }
+  return Nothing();
+}
+
+function isTopFunctionExpression(prefix: List<TokenTree>, exprAllowed: boolean) {
+  // P . function^l . x? . () . {}     where isExprPrefix(P, b, l) = false
+  return popRestMaybe(prefix)
+    .chain(([curly, rest]) => {
+      if (isBraces(curly)) {
+        return popRestMaybe(rest);
+      }
+      return Nothing();
+    })
+    .chain(([paren, rest]) => {
+      if (isParens(paren)) {
+        return popRestMaybe(rest);
+      }
+      return Nothing();
+    })
+    .chain(([optIdent, rest]) => {
+      if (isIdentifier(optIdent)) {
+        return popRestMaybe(rest);
+      }
+      return Maybe.of([optIdent, rest]);
+    })
+    .chain(([fnKwd, rest]) => {
+      if (isKeyword(fnKwd, 'function')) {
+        let l = getLineNumber(fnKwd);
+        if (l == null) {
+          throw new Error('Un-expected null line number');
+        }
+        return Maybe.of(isExprPrefix(l, exprAllowed, rest));
+      }
+      return Maybe.of(false);
+    }).getOrElse(false);
+}
+
+function isTopObjectLiteral(prefix: List<TokenTree>, exprAllowed: boolean) {
+  // P . {T}^l  where isExprPrefix(P, b, l) = false
+  return popRestMaybe(prefix)
+    .chain(([braces, rest]) => {
+      if (isBraces(braces)) {
+        let l = getLineNumber(braces);
+        if (l == null) {
+          throw new Error('Un-expected null line number');
+        }
+        return Maybe.of(!isExprPrefix(l, exprAllowed, rest));
+      }
+      return Maybe.of(false);
+    }).getOrElse(false);
+}
+
+export function isRegexPrefix(exprAllowed: boolean, prefix: List<TokenTree>) {
+  if (prefix.isEmpty()) {
+    // ε
+    return true;
+  } else if (isTopPunctuator(prefix)) {
+    // P . t   where t ∈ Punctuator
+    return true;
+  } else if (isTopStandaloneKeyword(prefix)) {
+    // P . t . t'  where t \not = "." and t' ∈ (Keyword \setminus  LiteralKeyword)
+    return true;
+  } else if (isTopParensWithKeyword(prefix)) {
+    // P . t . t' . (T)  where t \not = "." and t' ∈ (Keyword \setminus LiteralKeyword)
+    return true;
+  } else if (isTopFunctionExpression(prefix, exprAllowed)) {
+    // P . function^l . x? . () . {}     where isExprPrefix(P, b, l) = false
+    return true;
+  } else if (isTopObjectLiteral(prefix, exprAllowed)) {
+    // P . {T}^l  where isExprPrefix(P, b, l) = false
+    return true;
+  }
+  return false;
+}

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -328,25 +328,16 @@ export class RegExpToken extends BaseToken {
   }
 }
 
-export function isParens(x: any) {
-  if (x && typeof x.first === 'function') {
-    return hasType(x.first(), TT.LPAREN);
+const isDelimiterType = (x, type) => {
+  if (x && x[Symbol.iterator] && ([x] = x)) {
+    return x && hasType(x.value, type);
   }
   return false;
-}
+};
 
-export function isBraces(x: any) {
-  if (x && typeof x.first === 'function') {
-    return hasType(x.first(), TT.LBRACE);
-  }
-  return false;
-}
-export function isBrackets(x: any) {
-  if (x && typeof x.first === 'function') {
-    return hasType(x.first(), TT.LBRACK);
-  }
-  return false;
-}
+export function isParens(x: any) { return isDelimiterType(x, TT.LPAREN); }
+export function isBraces(x: any) { return isDelimiterType(x, TT.LBRACE); }
+export function isBrackets(x: any) { return isDelimiterType(x, TT.LBRACK); }
 
 export function getKind(x: List<TokenTree>) {
   return isParens(x) ? 'parens' :

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -330,7 +330,7 @@ export class RegExpToken extends BaseToken {
 
 const isDelimiterType = (x, type) => {
   if (x && x[Symbol.iterator] && ([x] = x)) {
-    return x && hasType(x.value, type);
+    return x && hasType(x, type);
   }
   return false;
 };

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -348,6 +348,12 @@ export function isBrackets(x: any) {
   return false;
 }
 
+export function getKind(x: List<TokenTree>) {
+  return isParens(x) ? 'parens' :
+         isBraces(x) ? 'braces' :
+         isBrackets(x) ? 'brackets' : '';
+}
+
 export function getLineNumber(t: TokenTree) {
   if (t.slice && t.slice.startLocation) {
     return this.token.slice.startLocation.line;

--- a/test/test-default-readtable.js
+++ b/test/test-default-readtable.js
@@ -14,14 +14,14 @@ function testParse(source, tst) {
 
   if (results.isEmpty()) return;
 
-  tst(results.first().token);
+  tst(results.first());
 }
 
 function testParseResults(source, tst) {
   const prevTable = getCurrentReadtable();
   const result = read(source);
   expect(getCurrentReadtable() === prevTable).to.be.true;
-  tst(result.map(s => s.token));
+  tst(result);
 }
 
 test('should parse Unicode identifiers', t => {
@@ -207,9 +207,9 @@ test('should parse template literals', t => {
     t.false(x.tail);
     t.true(x.interp);
 
-    t.true(List.isList(y.token));
-    t.is(y.token.get(1).token.type, TT.IDENTIFIER);
-    t.is(y.token.get(1).token.value, 'bar');
+    t.true(List.isList(y));
+    t.is(y.get(1).type, TT.IDENTIFIER);
+    t.is(y.get(1).value, 'bar');
 
     t.is(z.type, TT.TEMPLATE);
     t.is(z.value, 'baz');
@@ -222,7 +222,7 @@ test('should parse delimiters', t => {
   function testParseDelimiter(source, value) {
     testParse(source, results => {
       t.true(List.isList(results));
-      results.forEach((r, i) => t.true(source.includes(r.token.value)));
+      results.forEach((r, i) => t.true(source.includes(r.value)));
     });
   }
 
@@ -231,7 +231,7 @@ test('should parse delimiters', t => {
   testParse('{ x + z }', result => {
     t.true(List.isList(result));
 
-    const [v,w,x,y,z] = result.map(s => s.token);
+    const [v,w,x,y,z] = result;
 
     t.is(v.type, TT.LBRACE);
 
@@ -249,7 +249,7 @@ test('should parse delimiters', t => {
   testParse('[ x , z ]', result => {
     t.true(List.isList(result));
 
-    const [v,w,x,y,z] = result.map(s => s.token);
+    const [v,w,x,y,z] = result;
 
     t.is(v.type, TT.LBRACK);
 
@@ -267,13 +267,13 @@ test('should parse delimiters', t => {
   testParse('[{x : 3}, z]', result => {
     t.true(List.isList(result));
 
-    const [v,w,x,y,z] = result.map(s => s.token);
+    const [v,w,x,y,z] = result;
 
     t.is(v.type, TT.LBRACK);
 
     t.true(List.isList(w));
 
-    const [a,b,c,d,e] = w.map(s => s.token);
+    const [a,b,c,d,e] = w;
 
     t.is(a.type, TT.LBRACE);
 
@@ -299,7 +299,7 @@ test('should parse delimiters', t => {
     t.is(foo.type, TT.IDENTIFIER);
     t.is(foo.value, 'foo');
 
-    const [x,y,z] = bar.map(s => s.token);
+    const [x,y,z] = bar;
 
 
     t.is(x.type, TT.LPAREN);
@@ -351,7 +351,7 @@ test('should parse division expressions', t => {
 
 test('should parse syntax templates', t => {
   testParseResults('#`a 1 ${}`', ([result]) => {
-    const [u,v,w,x,y,z] = result.map(s => s.token);
+    const [u,v,w,x,y,z] = result;
     t.is(u.type, LSYNTAX);
 
     t.is(v.type, TT.IDENTIFIER);
@@ -364,8 +364,8 @@ test('should parse syntax templates', t => {
     t.is(x.value, '$');
 
     t.true(List.isList(y));
-    t.is(y.first().token.type, TT.LBRACE);
-    t.is(y.get(1).token.type, TT.RBRACE);
+    t.is(y.first().type, TT.LBRACE);
+    t.is(y.get(1).type, TT.RBRACE);
 
     t.is(z.type, RSYNTAX);
   });
@@ -380,7 +380,7 @@ test('should erase #lang pragmas', t => {
 test('should return an identifier for a lone #', t => {
   const results = read(`const # = 3`);
   t.true(List.isList(results));
-  t.is(results.get(1).token.type, TT.IDENTIFIER);
+  t.is(results.get(1).type, TT.IDENTIFIER);
 });
 
 test('should parse comments', t => {
@@ -405,7 +405,7 @@ test('should parse comments', t => {
 test('should properly update location information', t => {
   function testLocationInfo(source, { idx, size, line: expectedLine, column: expectedColumn}) {
     let result = read(source);
-    let { line, column } = result.get(idx).token.slice.startLocation;
+    let { line, column } = result.get(idx).slice.startLocation;
     t.is(result.size, size);
     t.is(line, expectedLine);
     t.is(column, expectedColumn);


### PR DESCRIPTION
The regex prefix stuff doesn't actually need to know anything inside of delimiters (only that it is a paren or bracket or brace). So, rather than force `isParens` etc know about terms, unwrap delimiters when putting them in the prefix.

/cc @gabejohnson 