### PR TITLE
Fix IdentiferExpression encountered after New/CallExpression

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 test/test262-parser-tests
+test/extra-parser-tests
 debug.js

--- a/src/enforester.js
+++ b/src/enforester.js
@@ -1285,6 +1285,7 @@ export class Enforester {
       } else if (this.isBraces(lookahead)) {
         this.term = this.enforestPrimaryExpression();
       } else if (this.isIdentifier(lookahead)) {
+        if (this.term) break;
         this.term = new T.IdentifierExpression({ name: this.enforestIdentifier() });
       } else {
         break;

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -1,17 +1,41 @@
-import read from '../src/reader/token-reader';
-import { compile } from '../src/sweet';
-import { Enforester } from '../src/enforester';
 import { List } from 'immutable';
+
+import read from '../src/reader/token-reader';
+import { compile, parse } from '../src/sweet';
+import { Enforester } from '../src/enforester';
 import StoreLoader from '../src/store-loader';
 
 export const stmt = x => x.items[0];
 export const expr = x => stmt(x).expression;
 export const items = x => x.items;
 
-
 export function makeEnforester(code) {
   let stxl = read(code);
   return new Enforester(stxl, List(), {});
+}
+
+function getAst(code) {
+  const store = new Map();
+  store.set('main.js', code);
+
+  const loader = new StoreLoader(__dirname, store);
+  return parse('main.js', loader);
+}
+
+function testParseWithOpts(t, acc, code, expectedAst) {
+  try {
+    t.deepEqual(expectedAst, acc(getAst(code)));
+  } catch (e) {
+    throw new Error(e.message);
+  }
+}
+
+export function testParse(t, acc, code, expectedAst) {
+  return testParseWithOpts(t, acc, code, expectedAst);
+}
+
+export function testParseComparison(t, acc, codeA, codeB) {
+  testParse(t, acc, codeA, acc(getAst(codeB)));
 }
 
 export function testParseFailure() {

--- a/test/test-parse.js
+++ b/test/test-parse.js
@@ -1,0 +1,19 @@
+import test from 'ava';
+
+import { items, testParseComparison } from './assertions';
+
+test('CallExpression followed by identifier', testParseComparison, items, `
+x
+foo.bar(1,2)
+x`, `
+x;
+foo.bar(1,2);
+x;`);
+
+test('NewExpression followed by identifier', testParseComparison, items, `
+x
+new Foo(1,2)
+x`, `
+x;
+new Foo(1,2);
+x;`);


### PR DESCRIPTION
```javascript
{
  foo = bar()
  baz = foo
}
// and
{
  foo = new bar()
  baz = foo
}
```
both result in:
```javascript
{
  foo = baz = foo;
}
```

This is because after enforestation of either a `CallExpression` or a `NewExpression` the while loop in `enforestLeftHandSideExpression` was either entered (in the case of `NewExpression`) or continued (in the case of `CallExpression`).

This PR fixes that by breaking or returning respectively.