### PR TITLE
Add experimental infix macro support

### DIFF
--- a/src/enforester.js
+++ b/src/enforester.js
@@ -137,6 +137,7 @@ export class Enforester {
     if (this.rest.size === 0) {
       this.done = true;
     }
+    this.prev = List.of(result);
     return result;
   }
 
@@ -1883,7 +1884,7 @@ export class Enforester {
 
       let ctx = new MacroContext(this, name, this.context, useSiteScope, introducedScope);
 
-      let result = sanitizeReplacementValues(syntaxTransform.value.call(null, ctx));
+      let result = sanitizeReplacementValues(syntaxTransform.value.call(null, ctx, this.prev));
       if (!List.isList(result)) {
         throw this.createError(name, 'macro must return a list but got: ' + result);
       }

--- a/src/token-expander.js
+++ b/src/token-expander.js
@@ -91,8 +91,7 @@ export default class TokenExpander extends ASTDispatcher {
     if (stxl.size === 0) {
       return List(result);
     }
-    let prev = List();
-    let enf = new Enforester(stxl, prev, this.context);
+    let enf = new Enforester(stxl, List(), this.context);
 
     while (!enf.done) {
       result.push(this.dispatch(enf.enforest()));

--- a/test/test-macro-expansion.js
+++ b/test/test-macro-expansion.js
@@ -241,3 +241,10 @@ syntax m = ctx => {
 }
 output = m
 `, 26);
+
+test('should support infix macros', evalWithOutput, `
+syntax m = (ctx, prev) => {
+  return prev;
+}
+output = 1 m
+`, 1);


### PR DESCRIPTION
Experiment is experimental.

Macros now take a second argument which is a single element list with the previous term.

In the old pre-1.0 days we allowed a list of *all* the previously enforested terms but this didn't behave well so I'm starting out with just a single term. We can argue our way into relaxing this restriction later.

Note that infix macros are contained within implicit delimiters so:

```js
syntax m = (ctx, prev) => {
  return prev;
}
1 + m
```

throws an error since `prev` is the empty list.