### PR TITLE
Change webpack output from AMD to UMD to support global.sweet

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "precommit": "lint-staged",
     "prebuild": "mkdir -p build/test build/sweet dist/",
     "build:src": "babel --out-dir build/src src",
-    "build:browser": "webpack build/src/browser-sweet.js --output-library-target amd --output-library sweet",
+    "build:browser": "webpack build/src/browser-sweet.js --output-library-target umd --output-library sweet",
     "build": "npm run build:src && npm run build:browser",
     "preprofile": "npm run build",
     "profile": "node --prof profile.js && node --prof-process *v8.log > v8-processed.log && rm *v8.log",


### PR DESCRIPTION
In the Gitter room we got a question about using sweet in the browser. The editor already uses a webpack bundle 😄. But it's AMD ☹️.

I changed the output type to `umd` to support all of the things. Now it should work with require.js, as a global and in node.