### PR TITLE
Wrap MacroContext::name in RawSyntax

### DIFF
--- a/src/macro-context.js
+++ b/src/macro-context.js
@@ -76,7 +76,7 @@ export default class MacroContext {
 
   name() {
     const { name } = privateData.get(this);
-    return name;
+    return new T.RawSyntax({ value: name });
   }
 
   contextify(delim: any) {

--- a/test/unit/test-macro-context.js
+++ b/test/unit/test-macro-context.js
@@ -4,10 +4,10 @@ import Syntax from '../../src/syntax';
 import { makeEnforester } from '../assertions';
 import { List } from 'immutable';
 
-test.skip('a macro context should have a name', t => {
+test('a macro context should have a name', t => {
   let enf = makeEnforester('a');
   let ctx = new MacroContext(enf, Syntax.fromIdentifier('foo'), {});
-  t.true(ctx.name().val() === 'foo');
+  t.true(ctx.name().value.val() === 'foo');
 });
 
 test('a macro context should be resettable', t => {


### PR DESCRIPTION
 fixes #658