### PR TITLE
Prevent operators from being recursively defined

### DIFF
--- a/src/syntax.js
+++ b/src/syntax.js
@@ -410,7 +410,9 @@ export default class Syntax {
     stxScopes = allScopes.concat(stxScopes);
     if (
       stxScopes.size === 0 ||
-      !(this.match('identifier') || this.match('keyword'))
+      !(this.match('identifier') ||
+        this.match('keyword') ||
+        this.match('punctuator'))
     ) {
       return this.token.value;
     }

--- a/test/unit/test-operators.js
+++ b/test/unit/test-operators.js
@@ -24,6 +24,17 @@ output = 1 neg`,
 );
 
 test(
+  'should not recursively define the unary operator',
+  evalWithOutput,
+  `
+operator - prefix 1 = (right) => {
+  return #\`-\${right}\`;
+}
+output = - 1`,
+  -1,
+);
+
+test(
   'should handle basic binary custom operators',
   evalWithOutput,
   `
@@ -87,4 +98,15 @@ let result = Id(1) >>= v => Id(v + 1)
 output = result.value;
   `,
   20,
+);
+
+test(
+  'should not recursively define the binary operator',
+  evalWithOutput,
+  `
+operator + left 2 = (left, right) => {
+  return #\`\${left} + \${right}\`;
+}
+output = 1 + 2`,
+  3,
 );


### PR DESCRIPTION
Custom operators were being recursively defined which caused:

```js
operator + left 2 = (left, right) => {
  return #`${left} + ${right}`;
}
```

to go into an infinite loop. Not good, this PR fixes that.