### PR TITLE
Add semicolons after function expressions in docs

### DIFF
--- a/doc/1.0/reference.adoc
+++ b/doc/1.0/reference.adoc
@@ -139,7 +139,7 @@ syntax m = function (ctx) {
 
   const b = ctx.next().value;
   return #`${a} + ${b} + 24`; // 30 + 42 + 24
-}
+};
 m 30 + 42 + 66
 ----
 
@@ -162,7 +162,7 @@ import { isStringLiteral } from 'sweet.js/helpers' for syntax;
 
 syntax m = ctx => {
   return isStringLiteral(ctx.next().value) ? #`'a string'` : #`'not a string'`;
-}
+};
 m 'foo'
 ----
 
@@ -204,7 +204,7 @@ syntax m = ctx => {
   let num = unwrap(delim).value.get(1);
   unwrap(num).value === 1;     // true
   // ...
-}
+};
 m foo (1)
 ----
 
@@ -225,7 +225,7 @@ syntax m = ctx => {
   let dummy = #`dummy`.get(0);
 
   return #`${fromIdentifier(dummy, 'bar')}`;
-}
+};
 m foo
 ----
 
@@ -258,7 +258,7 @@ syntax m = ctx => {
   let dummy = #`dummy`.get(0);
 
   return #`${fromNumber(dummy, 1)}`;
-}
+};
 m
 ----
 
@@ -309,7 +309,7 @@ import { fromPunctuator } from 'sweet.js/helpers' for syntax;
 syntax m = ctx => {
   let dummy = #`dummy`.get(0);
   return #`1 ${fromPunctuator(dummy, '+')} 1`;
-}
+};
 m
 ----
 
@@ -332,7 +332,7 @@ Create a new keyword syntax object with the value `kwd` using the lexical contex
 syntax m = ctx => {
   let dummy = #`dummy`.get(0);
   return #`${dummy.fromKeyword('let')} x = 1`;
-}
+};
 m
 ----
 
@@ -358,7 +358,7 @@ syntax m = ctx => {
   let dummy = #`dummy`.get(0);
   let block = #`let x = 1;`;
   return #`${fromBraces(dummy, block)}`;
-}
+};
 m
 ----
 
@@ -384,7 +384,7 @@ syntax m = ctx => {
   let dummy = #`dummy`.get(0);
   let elements = #`1, 2, 3`;
   return #`${fromBrackets(dummy, elements)}`;
-}
+};
 m
 ----
 
@@ -410,7 +410,7 @@ syntax m = ctx => {
   let dummy = #`dummy`.get(0);
   let expr = #`5 * 5`;
   return #`1 + ${fromParens(dummy, expr)}`;
-}
+};
 m
 ----
 
@@ -520,7 +520,7 @@ Syntax templates support interpolations just like normal templates via `${...}`:
 ----
 syntax m = function (ctx) {
   return #`${ctx.next().value} + 24`;
-}
+};
 m 42
 ----
 

--- a/doc/1.0/tutorial.adoc
+++ b/doc/1.0/tutorial.adoc
@@ -32,7 +32,7 @@ You can write it down as the following:
 ----
 syntax hi = function (ctx) {
   return #`console.log('hello, world!')`;
-}
+};
 hi
 ----
 
@@ -77,7 +77,7 @@ Consider the hello world example again:
 ----
 syntax hi = function (ctx) { // <1>
   return #`console.log('hello, world!')`; // <2>
-}
+};
 hi // <3>
 ----
 <1> Macro definition
@@ -111,7 +111,7 @@ syntax new = function (ctx) {
   let ident = ctx.next().value;
   let params = ctx.next().value;
   return #`${ident}.create ${params}`;
-}
+};
 
 new Droid('BB-8', 'orange');
 ----
@@ -160,7 +160,7 @@ syntax let = function (ctx) {
       ${ctx} // <2>
     }(${init}))
   `
-}
+};
 
 let bb8 = new Droid('BB-8', 'orange');
 console.log(bb8.beep());
@@ -209,7 +209,7 @@ syntax cond = function (ctx) {
     }
   }
   return result;
-}
+};
 
 let x = null;
 
@@ -272,7 +272,7 @@ syntax class = function (ctx) {
     }
   }
   return construct.concat(result);
-}
+};
 
 class Droid {
   constructor(name, color) {
@@ -309,7 +309,7 @@ Now that you've created your sweet macros you probably want to share them! Sweet
 'lang sweet.js';
 export syntax class = function (ctx) {
   // ...
-}
+};
 ----
 
 .main.js
@@ -344,7 +344,7 @@ let log = msg => console.log(msg);
 syntax m = ctx => {
   log('doing some Sweet things'); // ERROR: unbound variable `log`
   // ...
-}
+};
 ----
 
 We get an unbound variable error in the above example because `m`'s definition runs at a different _phase_ than the surrounding code: namely it runs at compiletime while the surrounding code is invoked at runtime.
@@ -369,7 +369,7 @@ import { log } from './log.js' for syntax;
 syntax m = ctx => {
   log('doing some Sweet things');
   // ...
-}
+};
 ----
 
 Adding `for syntax` to an import statement lets Sweet know that it needs to load the values being imported into the compiletime environment and make them available for macro definitions.
@@ -388,7 +388,7 @@ Operators are defined via the `operator` keyword:
 ----
 operator >>= left 1 = (left, right) => {
   return #`${left}.then(${right})`;
-}
+};
 
 fetch('/foo.json') >>= resp => { return resp.json() }
                    >>= json => { return processJson(json) }


### PR DESCRIPTION
To avoid more silly mistakes like https://github.com/sweet-js/sweet.js/issues/679#issuecomment-294068431 I've added semicolons to the end of all function expressions defining macros in the code samples.

I think a lot of people who try out Sweet start by copy/pasting from the tutorial. Currently, if they're going to be bitten by `[...]` and `(...)` following a `syntax`, `syntaxrec` or `operator` definition. This should ease some frustration.